### PR TITLE
Update links for GrimoireLab

### DIFF
--- a/Software/grimoirelab.md
+++ b/Software/grimoirelab.md
@@ -5,10 +5,10 @@ GrimoireLab is a set of free, open source software tools for software developmen
 
 **More Information:**
 
-GrimoireLab Website → https://grimoirelab.github.io
+GrimoireLab Website → https://chaoss.github.io/grimoirelab/
 
 GrimoireLab Code → https://github.com/grimoirelab
 
 GrimoireLab eating GrimoireLab → http://grimoirelab.biterg.io
 
-GrimoireLab Tutorial → https://grimoirelab.gitbooks.io/grimoirelab-training
+GrimoireLab Tutorial → https://chaoss.github.io/grimoirelab-tutorial


### PR DESCRIPTION
During the last months, all GrimoireLab repos moved to the CHAOSS GitHub organization. These are the new links, that should be used now.