### PR TITLE
Update how to contribute to website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ See the CHAOSS [contributing.md](https://github.com/chaoss/governance/blob/maste
 Content requests could include upcoming events you would like to see posted on the site, project specific information, or requested edits.
 
 ## News and blog posts
-To add news and blogs articles, please fork the repo and create a Markdown file in the news folder. When the pull request is accepted, the content will be added to the website.
+To add news and blogs articles, please fork the repo and create a Markdown file in the [Community/News](./Community/News) folder. Name the file with the current date 'YYYYMMDD_title.md When the pull request is accepted, the content will be added to the website.
 
 ## Wordpress/Github Markdown Content
 

--- a/Community/News/README.md
+++ b/Community/News/README.md
@@ -1,0 +1,1 @@
+Please create a new Markdown file for new blog posts with a name that start with today's date `YYYYMMDD_title.md`.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This repository is part of the CHAOSS Community, a Linux Foundation project focu
 ## How to Contribute
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-We are re-imagining the structure and content of the website. To contribute, leave a comment in the [Google Document](https://docs.google.com/document/d/1h4cxIzvrHe85BdxINHbd6oyhVbAVps6MTKTZRrFXNwU/edit) and email one of the maintainers to be included on the next call.
-
 ## Website Maintainers
 * Kevin Lumbard - klumbard@unomaha.edu
 * Georg Link - glink@unomaha.edu


### PR DESCRIPTION
We finished restructuring the website and can remove the notice from the README. Also update the CONTRIBUTING.md for where to submit blog posts.