### PR TITLE
Making it easier to find current upcoming events

### DIFF
--- a/Community/conferences.md
+++ b/Community/conferences.md
@@ -2,12 +2,6 @@
 
 Join us at conferences, workshops and hackathons.
 
-[Community Leadership Summit (July 14-15, 2018: Portland, USA)](http://www.communityleadershipsummit.com/)
-
-* CHAOSS members host the talk "Establishing Metrics that Matter for Diversity & Inclusion"
-
-[CHAOSSCon (August 28th, 2018: Vancouver, Canada)](http://chaoss.community/chaosscon-2018-NA)
-
 [Open Source Summit North America (August 29-31, 2018: Vancouver, Canada)](https://events.linuxfoundation.org/events/open-source-summit-north-america-2018/)
 
 CHAOSS member sessions at OSSNA:
@@ -17,3 +11,5 @@ CHAOSS member sessions at OSSNA:
 * [Diversity & Inclusion: Innovating to Create a Consistent Definition, Data and Metrics](http://sched.co/FANj)
 * [BoF: Software for Software Development Analytics: Status on CHAOSS Software Projects](http://sched.co/FAP5)
 * [Perceval, Graal and Arthur: The Quest for Software Project Data](http://sched.co/FAOp)
+
+CHAOSSCon EU (Tentatively February 1, 2019: Brussels, Belgium before FOSDEM) 

--- a/Participate/How-to-participate.md
+++ b/Participate/How-to-participate.md
@@ -1,11 +1,10 @@
 
-## How to Participate with CHAOSS?
+## How to Participate in CHAOSS?
 
 - Introduce yourself on the mailing list.
 - Join us in our weekly video conferences.
-- Come see us at Conferences, Workshops, and Hackathons.
 - Pick a project or workgroup and fork the GitHub repository.
+- Come see us at [conferences, workshops, and hackathons](https://chaoss.community/community/#user-content-upcoming-events).
 
 The CHAOSS community is dedicated to fostering an open and welcoming environment for contributors.
-
-Check out our [Code of Conduct](https://chaoss.community/about/code-of-conduct/).
+Please read our [Code of Conduct](https://chaoss.community/about/code-of-conduct/) to learn more about participating in CHAOSS.


### PR DESCRIPTION
Removed old conference and made that section easier to find from the participate page. Added CHAOSSCon EU with a tentative date. Improved clarity with a few adjustments to the participate page wording.