### PR TITLE
fix time zones and weekly call information

### DIFF
--- a/Participate/chaoss-weekly-and-monthly-calls.md
+++ b/Participate/chaoss-weekly-and-monthly-calls.md
@@ -1,7 +1,7 @@
 <a name="calls" id="calls"></a>
 ## CHAOSS Community Calls
 
-The CHAOSS community meets weekly on Tuesday at [11 am US Central time](http://arewemeetingyet.com/Chicago/2018-11-06/11:00/w/CHAOSS%20weekly%20meeting#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) for one hour. <a href="https://chaoss.github.io/website/Participate/CHAOSS-Calendar_WeeklySync.ics">Add to calendar (ICS file)</a>.
+The CHAOSS community meets every Tuesday at 11am CT (usually 18:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-06/11:00/w/CHAOSS%20weekly%20meeting#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) for one hour. <a href="https://chaoss.github.io/website/Participate/CHAOSS-Calendar_WeeklySync.ics">Add to calendar (ICS file)</a>.
 
 Join from PC, Mac, Linux, iOS or Android: https://unomaha.zoom.us/j/720431288<br/>
 Or Telephone: +1 408 638 0968 (US Toll) or <a href="https://unomaha.zoom.us/zoomconference?m=DKGo2mmIuOv9xSjphoGZZmYKxr5HFrS9">International numbers</a> (Meeting ID: 720 431 288)

--- a/Participate/chaoss-weekly-and-monthly-calls.md
+++ b/Participate/chaoss-weekly-and-monthly-calls.md
@@ -1,7 +1,7 @@
 <a name="calls" id="calls"></a>
 ## CHAOSS Community Calls
 
-The CHAOSS community meets every Tuesday at 11am CT (usually 18:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-06/11:00/w/CHAOSS%20weekly%20meeting#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) for one hour. <a href="https://chaoss.github.io/website/Participate/CHAOSS-Calendar_WeeklySync.ics">Add to calendar (ICS file)</a>.
+The CHAOSS community meets every Tuesday at 11am CT (usually 18:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-06/11:00/w/CHAOSS%20weekly%20meeting#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9)) for one hour. <a href="https://chaoss.github.io/website/Participate/CHAOSS-Calendar_WeeklySync.ics">Add to calendar (ICS file)</a>.
 
 Join from PC, Mac, Linux, iOS or Android: https://unomaha.zoom.us/j/720431288<br/>
 Or Telephone: +1 408 638 0968 (US Toll) or <a href="https://unomaha.zoom.us/zoomconference?m=DKGo2mmIuOv9xSjphoGZZmYKxr5HFrS9">International numbers</a> (Meeting ID: 720 431 288)

--- a/Participate/chaoss-weekly-and-monthly-calls.md
+++ b/Participate/chaoss-weekly-and-monthly-calls.md
@@ -1,7 +1,7 @@
 <a name="calls" id="calls"></a>
 ## CHAOSS Community Calls
 
-Every Tuesday at 18:00 CEST (9am PDT) for one hour. <a href="https://github.com/chaoss/website/releases/download/v1.0/CHAOSS-Calendar_WeeklySync.ics">Add to calendar</a>.
+The CHAOSS community meets weekly on Tuesday at [11 am US Central time](http://arewemeetingyet.com/Chicago/2018-11-06/11:00/w/CHAOSS%20weekly%20meeting#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) for one hour. <a href="https://chaoss.github.io/website/Participate/CHAOSS-Calendar_WeeklySync.ics">Add to calendar (ICS file)</a>.
 
 Join from PC, Mac, Linux, iOS or Android: https://unomaha.zoom.us/j/720431288<br/>
 Or Telephone: +1 408 638 0968 (US Toll) or <a href="https://unomaha.zoom.us/zoomconference?m=DKGo2mmIuOv9xSjphoGZZmYKxr5HFrS9">International numbers</a> (Meeting ID: 720 431 288)

--- a/Participate/diversity-inclusion-workgroup-weekly-call.md
+++ b/Participate/diversity-inclusion-workgroup-weekly-call.md
@@ -2,7 +2,7 @@
 
 This working group aims at bringing together experiences measuring diversity and inclusion in open source projects. Its main goal focuses on understanding from a qualitative and quantitative point of view how diversity and inclusion can be measured.
 
-The D&I work group meets weekly on Mondays at [11am US Central time](http://arewemeetingyet.com/Chicago/2018-11-05/11:00/w/CHAOSS%20D%26I%20WG#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) via [Zoom](https://unomaha.zoom.us/j/720431288).
+The D&I work group meets every Monday at 9:30am CT (usually 16:30 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-05/09:30/w/CHAOSS%20D%26I%20WG#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) via [Zoom](https://unomaha.zoom.us/j/720431288).
 
 Info about workgroup: https://github.com/chaoss/wg-diversity-inclusion
 Join the [D&I mailing list](https://lists.linuxfoundation.org/mailman/listinfo/chaoss-diversity-inclusion).

--- a/Participate/diversity-inclusion-workgroup-weekly-call.md
+++ b/Participate/diversity-inclusion-workgroup-weekly-call.md
@@ -2,7 +2,7 @@
 
 This working group aims at bringing together experiences measuring diversity and inclusion in open source projects. Its main goal focuses on understanding from a qualitative and quantitative point of view how diversity and inclusion can be measured.
 
-The D&I work group meets every Monday at 9:30am CT (usually 16:30 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-05/09:30/w/CHAOSS%20D%26I%20WG#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) via [Zoom](https://unomaha.zoom.us/j/720431288).
+The D&I work group meets every Monday at 9:30am CT (usually 16:30 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-05/09:30/w/CHAOSS%20D%26I%20WG#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9)) via [Zoom](https://unomaha.zoom.us/j/720431288).
 
 Info about workgroup: https://github.com/chaoss/wg-diversity-inclusion
 Join the [D&I mailing list](https://lists.linuxfoundation.org/mailman/listinfo/chaoss-diversity-inclusion).

--- a/Participate/diversity-inclusion-workgroup-weekly-call.md
+++ b/Participate/diversity-inclusion-workgroup-weekly-call.md
@@ -1,7 +1,8 @@
-### Diversity and Inclusion Bi-Weekly Call
+### Diversity and Inclusion Weekly Call
 
 This working group aims at bringing together experiences measuring diversity and inclusion in open source projects. Its main goal focuses on understanding from a qualitative and quantitative point of view how diversity and inclusion can be measured.
 
-The work group meets weekly on Mondays at 18:00 CEST (9am PDT) via [Zoom](https://unomaha.zoom.us/j/720431288).
+The D&I work group meets weekly on Mondays at [11am US Central time](http://arewemeetingyet.com/Chicago/2018-11-05/11:00/w/CHAOSS%20D%26I%20WG#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) via [Zoom](https://unomaha.zoom.us/j/720431288).
 
 Info about workgroup: https://github.com/chaoss/wg-diversity-inclusion
+Join the [D&I mailing list](https://lists.linuxfoundation.org/mailman/listinfo/chaoss-diversity-inclusion).

--- a/Participate/growth-maturity-decline-weekly-call.md
+++ b/Participate/growth-maturity-decline-weekly-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on Growth-Maturity-Decline metrics and software. The goal is to refine the metrics that inform Growth-Maturity-Decline and to work with software implementations.
 
-The GMD work group meets weekly on Wednesdays at [11am US Central time](http://arewemeetingyet.com/Chicago/2018-11-07/11:00/w/CHAOSS%20GMD%20Meeting#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) via [Zoom](https://unomaha.zoom.us/j/720431288).
+The GMD work group meets every Wednesday at 11am CT (usually 18:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-07/11:00/w/CHAOSS%20GMD%20Meeting#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9)) via [Zoom](https://unomaha.zoom.us/j/720431288).
 
 Info about workgroup: [https://github.com/chaoss/wg-gmd](https://github.com/chaoss/wg-gmd)

--- a/Participate/growth-maturity-decline-weekly-call.md
+++ b/Participate/growth-maturity-decline-weekly-call.md
@@ -1,7 +1,7 @@
-### Growth Maturity and Decline Bi-Weekly Call
+### Growth Maturity and Decline Weekly Call
 
 This Working Group focuses on Growth-Maturity-Decline metrics and software. The goal is to refine the metrics that inform Growth-Maturity-Decline and to work with software implementations.
 
-The work group meets bi-weekly. The next call will be on Wednesday, Sep 26th at 18:00 CEST (9am PDT) via [Zoom](https://unomaha.zoom.us/j/720431288).
+The GMD work group meets weekly on Wednesdays at [11am US Central time](http://arewemeetingyet.com/Chicago/2018-11-07/11:00/w/CHAOSS%20GMD%20Meeting#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9) via [Zoom](https://unomaha.zoom.us/j/720431288).
 
 Info about workgroup: [https://github.com/chaoss/wg-gmd](https://github.com/chaoss/wg-gmd)


### PR DESCRIPTION
- standardize all time information to US Central to avoid daylight savings problems
- include a link to arewemeetingyet.com for an updating reference and timezone conversion and link to add to calendar
- fix bi-weekly to weekly for workgroups.