### PR TITLE
Add CHAOSScon EU 2019 schedule template to website

### DIFF
--- a/CHAOSScon/2019EU/cfp.md
+++ b/CHAOSScon/2019EU/cfp.md
@@ -1,71 +1,11 @@
 # Call for Participation
 ## Submit a Proposal
-If you are interested in speaking at CHAOSSCon EU on February 1, 2019,
-please read through the rest of this page to understand the types of talks
-that are appropriate for this conference, and then [submit your proposal](https://docs.google.com/forms/d/e/1FAIpQLSeKcLPkAUucB1K32FW48IYJM7Jbi_jI2MkFAhj0TPYQhJZJgQ/viewform).  
+Submission is now closed.
 
 ## Dates to Remember:
 * CFP Opens: October 4, 2018
 * CFP Closes: November 26, 2018
 * CFP Notifications: December 3, 2018
-* Schedule Announcement: December 10, 2018
+* Schedule Announcement: December 18, 2018
 * Slide Due Date: January 29, 2019
 * Event Date: February 1, 2019
-
-## Suggested Topics:
-- **Software related topics:**
-   + tutorials
-   + walk throughs
-   + demos
-   + how-to's
-   + new features
-- **Metric related topics:**
-   + metrics strategy
-   + deep dive into the use of metrics
-   + failure of metrics in practice
-   + lessons learned, use cases, and case studies
-   + proposals for new metrics
-   + new visualizations
-
-## Important Notes
-- All speakers are required to adhere to our [Code of Conduct](https://github.com/chaoss/governance/blob/master/code-of-conduct.md).
-- One complimentary pass for the event will be provided per submission.
-- Do not propose sales or marketing pitches. Do not include unlicensed or potentially closed-source technologies when preparing your proposal. These talks will be rejected due to the fact that they take away from the integrity of our events and are rarely well-received by conference attendees.
-- All accepted speakers are required to submit their slides prior to the event.
-
-
-## Preparing To Submit Your Proposal
-While it is not our intention to provide you with strict instructions on how to prepare your proposal, we hope you will take a moment to review the following guidelines that we have put together to help you prepare the best submission possible. To get started, here are three things that you should consider before submitting your proposal:
-1. What are you hoping to get from your presentation?
-2. What do you expect the audience to gain from your presentation?
-3. How will your presentation help better the ecosystem?
-There are plenty of ways to give a presentation about projects and technologies without focusing on company-specific efforts. Remember the things to consider that we mentioned above when writing your proposal and think of ways to make it interesting for attendees while still letting you share your experiences, educate the community about an issue, or generate interest in a project.
-
-### Session Types
-
-You will need to choose a session type when submitting:
-* Lightning Talk (5 - 10 minutes)
-* Regular Session (20 - 30 minutes)
-* Hands-On Workshop (approximately 60 minutes)
-
-### Abstract
-This is your chance to *sell* your talk to the program committee, so do your best to highlight the problem/contribution/work that you are addressing in your presentation. The technical details are still important, but the relevance of what you are presenting will help the program committee during the selection process.
-This is the abstract that will be posted on the website schedule, so please ensure that it is in complete sentences (and not just bullet points) and that it is written in the third person (use your name instead of I). Your abstract is limited to 1500 characters (~200 words).
-*Example: The proposed presentation will provide an overview and current status of the Linux Foundation's CHAOSS project. This will include a discussion of the CHAOSS project workgroups, with a particular focus on the technical advances that are being done with respect to understanding the growth, maturity, and decline of an open source project. The presentation will conclude with a discussion of future work of the CHAOSS project, as well as ways to become involved in the project.*
-
-### Audience
-Describe who the audience is and what you expect them to gain from your presentation.
-*Example: The audience for this project includes organizational members who are interested in better understand the growth, maturity, and decline of the open source projects with which they are engaged. This could include corporate participants, community managers, and members from supporting foundations.*
-
-### Experience Level
-Select the experience level (Beginner, Intermediate, Advanced, Any) of those who should attend this session.
-### First Time Submitting? Don’t Feel Intimidated
-This is a friendly audience and an excellent way to get to know the community and share your ideas and the work that you are doing, so we strongly encourage first-time speakers to submit talks. In the instance that you aren’t sure about your abstract, reach out to us and we will be more than happy to work with you on your proposal.
-
-### How To Give a Great Tech Talk
-In the instance that your talk is accepted, we want to make sure that you give the best presentation possible. To do this, we enlisted the help of seasoned conference speaker Josh Berkus who has prepared an in-depth tutorial on “How to Give a Great Tech Talk”:
-[Part 1](http://www.youtube.com/watch?v=iE9y3gyF8Kw>) and 
-[Part 2](http://www.youtube.com/watch?v=gcOP4WQfJl4>)
-
-# Schedule
-To be announced: TBA

--- a/CHAOSScon/2019EU/schedule.md
+++ b/CHAOSScon/2019EU/schedule.md
@@ -1,43 +1,35 @@
-# Schedule: Tuesday, August 28, 2018
+# Schedule: Friday, February 1, 2019
+
+_**Note:** Speakers are added to schedule once they are confirmed_
 
 | Time | Topic | Speaker | Slides |
 |---|---|---|---|
-| 8:30 - 9:30 | Registration & Networking (Room: B213) | | |
+| 9:00 - 10:00 | Registration & Networking |   |   |
 |   |   |   |   |
-| 9:30 - 10:00 | **Keynote** (Room: B213) | [Matt Germonprez](#user-content-matt-germonprez) | [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/CHAOSSCon.Keynote.pdf)  |
+| 10:00 - 10:30 | **Keynote 1** | TBA |   |
+| 10:30 - 11:00 | **Keynote 2** | TBA |   |
 |   |   |   |   |
-| 10:00 - 11:00 | **Plenaries** (Room: B213) | | |
-| | If There Are No Metrics, Did It Even Happen? Tracking Open Source Contributions at Comcast | [Shilla Saebi](#user-content-shilla-saebi) & [David Grizzanti](#user-content-david-grizzanti) | [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/if-there-are-no-metrics-did-it-even-happen.pdf) |
-| | Open Source Metrics at Twitter | [Remy DeCausemaker](#user-content-remy-decausemaker) | [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/twitteross.pdf) |
-| | Towards GrimoireLab 1.0: a roadmap | [Santiago Dueñas](#user-content-santiago-dueñas) & [Valerio Cosentino](#user-content-valerio-cosentino) | [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/Towards-GrimoireLab-1.0.pdf) |
+| 11:00 - 11:20 | Talk 1 | TBA |   |
+| 11:20 - 11:40 | Talk 2 | TBA |   |
+| 11:40 - 12:00 | Talk 3 | TBA |   |
 |   |   |   |   |
-| 11:00 - 11:30 | Break & Networking | | |
+| 12:00 - 13:00 | Lunch |   |   |
 |   |   |   |   |
-| 11:30 - 12:30 | **Plenaries** (Room: B213) | | |
-| | Pains and tribulations of finding data | [John Hawley](#user-content-john-hawley) & [Alex Courouble](#user-content-alex-courouble)| [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/pains-and-tribulations-of-finding-data.pdf) |
-| | Identifying Metrics to Communicate the Value of Open Source Contributions | [Ben Lloyd Pearson](#user-content-ben-lloyd-pearson) | [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/communicating-value-of-open-source-metrics.pdf) |
-| | Chaos or CHAOSS: What We Hear From the CHAOSS Community  | [Georg Link](#user-content-georg-jp-link) & [Kevin Lumbard](#user-content-kevin-lumbard) | [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/Chaos-or-CHAOSS.pdf) |
-|   |   |   | |
-| 12:30 - 1:15 | **Panel:** Diversity & Inclusion: Innovating to Create a Consistent Definition, Data and Metrics | [Matt Germonprez](#user-content-matt-germonprez) (Moderator), [Emma Irwin](#user-content-emma-irwin), [Dawn Foster](#user-content-dawn-foster), [Jesus Gonzalez-Barahona](#user-content-jesus-m-gonzalez-barahona), [Sean Goggins](#user-content-sean-goggins) | |
-|   |   |   | |
-| 1:15 - 2:30 | Lunch and Networking | | |
-|   |   |   | |
-| 2:30 - 3:00 | **Lightning Talks** (Room: B213) | (Signup on site) | |
-|   | Ask, Join, Share  | Felipe Hoffa  |   |
-|   | Santi: Percival Demo  | Manrique López  | [notebook](https://colab.research.google.com/drive/1oXFbph7FeuQn2vNtPmwdLzijpSp65T1A) |
-|   | GrimoireLab to track GSoC  | Jesus Gonzales-Barahona  |   |
-|   | Community Health Visibility  | Johanna Smith  |   |
-|   | Augur Demo  | Sean Goggins  |   |
-|   | Risk Category brainstorming  | Matt Snell  | [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/risk_metrics.pdf) |
-|   |   |   | |
-| 3:00 - 4:00 | **Workshops / Tutorials** | | |
-| Room: B213 | CHAOSS WG on Growth-Maturity-Metrics: status report | [Jesus Gonzalez-Barahona](#user-content-jesus-m-gonzalez-barahona) & [Sean Goggins](#user-content-sean-goggins) | |
-| Room: B215 | Which house are you in? (Sorting Hat workshop) | [Santiago Dueñas](#user-content-santiago-dueñas) & [Valerio Cosentino](#user-content-valerio-cosentino) | |
-|   |   |   | |
-| 4:00 - 4:30 | Break & Networking | | |
-|   |   |   | |
-| 4:30 - 5:30 | **Workshops / Tutorials** | | |
-| Room: B213  | Establishing Metrics that Matter for Diversity & Inclusion | [Emma Irwin](#user-content-emma-irwin) | |
-| Room: B215  | GrimoireLab made simple: Using the basic stuff from Python | [Jesus Gonzalez-Barahona](#user-content-jesus-m-gonzalez-barahona) | [PDF](https://chaoss.github.io/website/CHAOSScon/2018NA/slides/GrimoireLab-made-simple.pdf) |
-|   |   |   | |
-| 5:30 - | Adjourn somewhere for more networking | | |
+| 13:00 - 13:30 | **Keynote 3** | TBA |   |
+|   |   |   |   |
+| 13:30 - 13:50 | Talk 4 | TBA |   |
+| 13:50 - 14:10 | Talk 5 | TBA |   |
+| 14:10 - 14:30 | Talk 6 | TBA |   |
+|   |   |   |   |
+| 14:30 - 15:10 | Break |   |   |
+|   |   |   |   |
+| 15:10 - 15:50 | Lightning Talks |   |   |
+|   | - TBA |   |   |
+|   | - TBA |   |   |
+|   | - TBA |   |   |
+|   | (You may sign up to give a Lightning Talk during the event; First come first serve.)  |   |   |
+|   |   |   |   |
+| 15:50 - 16:50 | Diversity & Inclusion Workgroup Tutorial | [Dawn Foster](#user-content-dawn-foster) & [Daniel Izquierdo](#user-content-daniel-izquierdo)  |   |
+| 16:50 - 17:50 | Growth-Maturity-Decline Workgroup Tutorial | [Jesus M. Gonzalez-Barahona](#user-content-jesus-m-gonzalez-barahona) & [Sean Goggins](#user-content-sean-goggins) |   |
+|   |   |   |   |
+| 17:50 | Adjourn to FOSDEM Beer Event |   |   |

--- a/CHAOSScon/2019EU/speakers.md
+++ b/CHAOSScon/2019EU/speakers.md
@@ -1,28 +1,10 @@
 ## Speakers
 
-### Alex Courouble
+### Daniel Izquierdo
 
-_Open Source Engineer - VMware_
+_Data Analyst - Bitergia_
 
-Alex is an Open Source Engineer at VMware Open Source Technology Center, where he works on VMware open source contribution analytics. Before VMware, Alex was a getting his masters in Software Engineering at Polytechnique Montreal, where he researched collaboration and contribution in Open Source communities. Outside of work, Alex enjoys hiking, running, and playing Hockey with his friends.
-
-### Ben Lloyd Pearson
-
-_Governor of GitHub - Oath_
-
-Ben Lloyd Pearson (M.Sc.) manages the GitHub presence and assists with external open source involvement at Oath. He has a background that spans many areas of technology including developer operations, digital media, audio / video production, web development, IT systems support / administration, and technical writing. He is an IT generalist who uses his broad understanding of technology to facilitate open source software development, and he has been involved with a range of open source communities. He has supports both internal and community open source efforts through infrastructure administration, technical evangelism, and developer operations. Ben excels at combining deep technical comprehension with a strong business acumen to provide valuable, strategic information.
-
-### David Grizzanti
-
-_Principal Software Engineer - Comcast_
-
-David Grizzanti is a Principal Software Engineer at Comcast. He oversees the development of multi-tenant software platforms that support tens of millions of customers across North America. David has more than 10+ years of software experience. Prior to joining Comcast, he participated in 3 IaaS platform builds in his time at Sungard Availability Services. His general areas of interests include software architecture, DevOps/QA, and engineering leadership.
-
-### Emma Irwin
-
-_Open Project & Communities Specialist - Mozilla_
-
-During successful career as a software developer, Emma discovered Open Source, and was inspired by the potential of developing software, and participating in communities connected by common purpose and mission. Her experience as a contributor to many projects including Drupal, Wordpress and Firefox inspired her to help others get involved - and thus reshaped career focus to doing just that at Mozilla with a focus on diversity & inclusion. Emma leads D&I strategy development for Mozilla's communities, and lives in Sooke, BC with her family.
+Daniel Izquierdo is co-founder of Bitergia, a start-up focused on providing metrics and consultancy about open source projects. His main interests about open source are related to the community itself, trying to help community managers, organizations and developers to better understand how the project is performing. He has contributed to several open analytics dashboards such as the OpenStack, Wikimedia or Xen. He has participated as speaker giving details about gender diversity in OpenStack, InnerSource metrics strategy at OSCON, and other metrics-related talks.
 
 ### Dawn Foster
 
@@ -30,67 +12,14 @@ _Consultant - Scale Factory_
 
 Dawn is currently a consultant at The Scale Factory and is finishing a PhD at the University of Greenwich in London. She spent more than 20 years working at companies like Puppet Labs, Intel, Jive Software, and more. She has expertise in community building, open source software, metrics, and more. She is passionate about bringing people together through a combination of online communities and real-world events along with analyzing the data associated with participation in developer and open source communities. She has spoken at dozens of industry events, including many Linux Foundation events, OSCON, SXSW, FOSDEM and more.
 
-### Georg J.P. Link
-
-_PhD Student - University of Nebraska at Omaha_
-
-Georg J.P. Link is a Ph.D. student at the University of Nebraska at Omaha. His research advances our knowledge in corporate engagement with open source projects. As corporate involvement increases, open source foundations provide guidance and support for open source projects. We only begin to understand the evolution of this triangular relationship. Link's current research focus is to inform this relationship through research into open source project health (CHAOSS project) and new market mechanisms (Bugmark project).
-
 ### Jesus M. Gonzalez-Barahona
 
 _Founder - Bitergia / Professor - Uni. Rey Juan Carlos_
 
 Jesus M. Gonzalez-Barahona is co-founder of Bitergia, the software development analytics company specialized in the analysis of free / open source software projects. He is also professor in Universidad Rey Juan Carlos (Spain), in the context of the GSyC/LibreSoft research group. His interests include the study of communities of software development, with a focus on quantitative and empirical studies. He enjoys taking photos of the coffee he drinks around the world.
 
-### John Hawley
-
-_Open Source Engineer - VMware_
-
-John 'Warthog9' Hawley led the system administration team on kernel.org for nearly a decade, leading a team including four other administrators. His other exploits include working on Syslinux, OpenSSI, a caching Gitweb, and patches to bind to enable GeoDNS. He's the author of PXE Knife, a set of interfaces around common utilities and diagnostics tools needed by an average systems administrator, as well as SyncDiff(erent) a state-full file synchronizer and file transfer mechanism. He currently works for VMware working on upstream Open Source Software. In his free time he enjoys cooking extravagant meals and watching bad movies.
-
-### Kevin Lumbard
-
-_PhD Student - University of Nebraska at Omaha_
-
-Kevin Lumbard is interested in peer production communities, open source software development, design, and project management in distributed environments. His research focus includes the liminal qualities of individuals engaged in open source communities, coordinating design practices, information exchange in open source design, and all things wicked.
-
-### Matt Germonprez
-
-_Professor - University of Nebraska at Omaha_
-
-Matt Germonprez is the Mutual of Omaha Associate Professor of Information Systems in the College of Information Science & Technology at the University of Nebraska at Omaha. He uses qualitative field-studies to research corporate engagement with open communities and the dynamics of design in these engagements. His lines of research have been funded by numerous organizations including the National Science Foundation, the Alfred P. Sloan Foundation, and Mozilla. Matt is the co-founder of the Association for Information Systems SIGOPEN and the Linux Foundation Community Health Analytics OSS Project (CHAOSS). He and has had work accepted at ISR, MISQ, JAIS, JIT, ISJ, I&O, CSCW, OpenSym, Group, HICSS, and ACM Interactions. Matt is an active open source community member, having presented design and development work at LinuxCon, the Open Source Summit North America, the Linux Foundation Open Compliance Summit, the Linux Foundation Collaboration Summit, and the Open Source Leadership Summit.
-
-### Nicole Huesman
-
-_Community & Developer Advocate - Intel Corporation_
-
-For over 20 years, Nicole has applied her aptitude in storytelling to the technology industry—helping shine a light on the importance of the work of her engineering colleagues in a way that delivers true business value. She dove into the world of open source at Intel seven years ago, and quickly became a strong advocate—across Linux, cloud/virtualization (OpenStack, KVM, Xen), IoT (Yocto Project), Android, web technologies (HTML5), and more. She is passionate about cultivating inclusive communities that welcome diverse perspectives and invite intelligent, thoughtful debate to benefit us all. As co-chair of the CHAOSS Project's Diversity & Inclusion Workgroup, she is helping establish a consistent, cross-community definition and metrics for diversity. She also helps lead speed mentoring workshops across the OpenStack and Linux communities, inspiring the next generation of contributors, as an active member of the Women of OpenStack and Women in Open Source groups. She is a frequent moderator, speaker and blogger in the areas of diversity and mentorship.
-
-### Remy DeCausemaker
-
-_Open Source Program Manager - Twitter_
-
-As a Civic Hacker, Hackademic, and Program Manager of Twitter Open Source, @Remy_D builds communities that use their powers for good.
-
-### Santiago Dueñas
-
-_- Bitergia_
-
-Santiago Dueñas is an open source advocate and a software engineer at Bitergia. He is part of CHAOSS community and currently leads the development of GrimoireLab platform. Before joining Bitergia, Santiago was part of LibreSoft, a research team at Universidad Rey Juan Carlos, where he studied different facets of libre software such as development processes, coordination and involvement in open source projects and their communities.
-
 ### Sean Goggins
 
 _Professor - University of Missouri_
 
 Sean is an open source software researcher and a founding member of the Linux Foundation’s working group on community health analytics for open source software CHAOSS, co-lead of the CHAOSS metrics software working group and leader of the open source metrics tool AUGUR which can be forked and cloned and experimented with on GitHub. After a decade as a software engineer, Sean decided his calling was in research. His open source research is framed around a broader agenda of social computing research, which he pursues as an associate professor of computer science at the University of Missouri.
-
-### Shilla Saebi
-
-_Open Source Program Manager - Comcast_
-
-Shilla Saebi is an Open Source Program Manager who focuses on community and has been with Comcast for almost a decade. She has worked in many diverse roles within the tech industry in positions ranging from operations engineering, system administration, and network operations. Shilla is an open source contributor and actively supports several open source projects housed under the Linux Foundation, Apache, and OpenStack. From 2014-2017, she was nominated to serve as a member of the OpenStack User Committee by the existing board members, becoming the first woman to serve on OpenStack’s UC. She was also a core contributor to the OpenStack docs project and currently sits on the Editorial Advisory Board for OpenStack Superuser magazine. Shilla also served on the board of the OpenStack Innovation Center (OSIC) from 2015-2017, where she helped the community develop and test code at scale, and is currently an OpenStack ambassador for the East Coast USA. Outside of the world of open source, she loves music, traveling, and art. Shilla is based in Philadelphia, PA.
-
-### Valerio Cosentino
-_Software Developer - Bitergia_
-
-Valerio is a software developer at Bitergia since September 2017. He got his M.Sc. in computer science in 2010 and Ph.D. in computer science in 2013. His interests cover source code analysis, (software) data extraction and reverse engineering. Before joining Bitergia, he has been a Ph.D. student at IBM France and postdoctoral fellow in a couple of research teams between France and Spain, where he worked on reverse engineering of legacy systems, analysis of open source projects (e.g., maturity, bus factor) and open data. In his free time he enjoys running and playing videogames.


### PR DESCRIPTION
@klumb can you please add two section to display on the website 'schedule.md' and 'speakers.md'

We will add more details as we get confirmation from speakers.