### PR TITLE
add D&I agenda and meeting minutes to /participate page

### DIFF
--- a/Participate/diversity-inclusion-workgroup-weekly-call.md
+++ b/Participate/diversity-inclusion-workgroup-weekly-call.md
@@ -2,7 +2,7 @@
 
 This working group aims at bringing together experiences measuring diversity and inclusion in open source projects. Its main goal focuses on understanding from a qualitative and quantitative point of view how diversity and inclusion can be measured.
 
-The D&I working group meets every Monday at 9:30am CT (usually 16:30 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-05/09:30/w/CHAOSS%20D%26I%20WG#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9)) via [Zoom](https://unomaha.zoom.us/j/720431288).
+The D&I working group meets every Monday at 9:30am CT (usually 16:30 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-05/09:30/w/CHAOSS%20D%26I%20WG#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9)) via [Zoom](https://unomaha.zoom.us/j/720431288). -- [Agenda and meeting minutes](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit)
 
 Info about working group: https://github.com/chaoss/wg-diversity-inclusion
 


### PR DESCRIPTION
This pull request adds a link on the /participate page to a shared google doc for D&I WG agenda and meeting minutes.

