### PR TITLE
Add pages for next two CHAOSScon

### DIFF
--- a/CHAOSScon/2019NA/desc.md
+++ b/CHAOSScon/2019NA/desc.md
@@ -1,0 +1,25 @@
+## About CHAOSScon
+
+Meet the CHAOSS community. Learn about metrics and tools used by several open source projects, communities, and engineering teams to track and analyze their development activities, communities health, diversity, risk, and value.
+
+This conference will include CHAOSS updates, use cases, and hands-on workshops for developers, community managers, project managers, and anyone interested in measuring open source project health.
+
+Specific CHAOSS software highlighted will be GrimoireLab and Augur with their respective updates and demos.
+
+We will also share insights from the CHAOSS workgroups on *Diversity and Inclusion*, *Growth-Maturity-Decline*, *Risk*, and *Value* that branched out from the CHAOSS metrics work.
+
+## Where?
+TBD
+
+Co-located with [Open Source Summit North America 2019](https://events.linuxfoundation.org/events/open-source-summit-north-america-2019/attend/about/)
+
+## When?
+
+TBD
+
+Possibly August 20 or 24.
+
+
+## Organizing Committee
+
+TBD

--- a/CHAOSScon/2019NA/schedule.md
+++ b/CHAOSScon/2019NA/schedule.md
@@ -1,0 +1,3 @@
+## Call for Participation
+
+We will announce on our [mailing list](https://chaoss.community/participate) when we open a call for participation.

--- a/CHAOSScon/2019NA/speakers.md
+++ b/CHAOSScon/2019NA/speakers.md
@@ -1,0 +1,3 @@
+## Speakers
+
+Speakers will be announced after the call of participation ended.

--- a/CHAOSScon/2020EU/desc.md
+++ b/CHAOSScon/2020EU/desc.md
@@ -1,0 +1,26 @@
+## About CHAOSScon
+
+Meet the CHAOSS community. Learn about metrics and tools used by several open source projects, communities, and engineering teams to track and analyze their development activities, communities health, diversity, risk, and value.
+
+This conference will include CHAOSS updates, use cases, and hands-on workshops for developers, community managers, project managers, and anyone interested in measuring open source project health.
+
+Specific CHAOSS software highlighted will be GrimoireLab and Augur with their respective updates and demos.
+
+We will also share insights from the CHAOSS workgroups on *Diversity and Inclusion*, *Growth-Maturity-Decline*, *Risk*, and *Value* that branched out from the CHAOSS metrics work.
+
+## Where?
+
+IBIS Hotel<br />
+Brussels, Belgium
+
+Co-located with FOSDEM
+
+## When?
+
+TBD
+
+Some time around FOSDEM
+
+## Organizing Committee
+
+TBD

--- a/CHAOSScon/2020EU/schedule.md
+++ b/CHAOSScon/2020EU/schedule.md
@@ -1,0 +1,3 @@
+## Call for Participation
+
+We will announce on our [mailing list](https://chaoss.community/participate) when we open a call for participation.

--- a/CHAOSScon/2020EU/speakers.md
+++ b/CHAOSScon/2020EU/speakers.md
@@ -1,0 +1,3 @@
+## Speakers
+
+Speakers will be announced after the call of participation ended.


### PR DESCRIPTION
At the Governing Board meeting, we discussed that the next two CHAOSScon will be at:

* Open Source Summit North America 2020
* FOSDEM 2020

This pull request is to add a the markdown files we will need for the pages.

@klumb When you get a chance, could you please create two pages on Wordpress for CHAOSSconNA18 and CAHOSSconEU20 ?