### PR TITLE
updated info about the Value WG

### DIFF
--- a/About/About/who-are-we.md
+++ b/About/About/who-are-we.md
@@ -17,3 +17,5 @@ The goal of the working groups is to refine the metrics and to work with softwar
 - Growth-Maturity-Decline WG
 
 - Common Metrics WG
+
+- Value Metrics WG

--- a/Metrics/value.md
+++ b/Metrics/value.md
@@ -1,5 +1,6 @@
-### value
+### Value
 
-Developers and organizations capture value from engaging in OSS communities. This category can inform what this value is.
+Economic value is expressed in different ways for different types of stakeholders. Lack of metrics makes it difficult for business decision makers to compare open-source and to allocate resources optimally across projects, slowing decision making and product innovation. The main goal is to publish trusted industry-standard Value Metrics. A kind of S&P for software development, an authoritative source for metrics significance and industry norms.
 
-Goals and Questions related to Value are located at (https://github.com/chaoss/metrics/blob/master/4_Value.md)
+Value Repository → https://github.com/chaoss/wg-value/
+

--- a/Participate/value-workgroup-weekly-call.md
+++ b/Participate/value-workgroup-weekly-call.md
@@ -1,0 +1,7 @@
+### Value WG
+
+This Working Group focuses on industry-standard metrics for economic value in open source. The main goal is to publish trusted industry-standard Value Metrics. A kind of S&P for software development, an authoritative source for metrics significance and industry norms.
+
+The VMG team meets every Friday from 9-10 Pacific Time (usually 11am US Central Time). All are welcome.[check your local time](http://arewemeetingyet.com/Chicago/2019-03-29/11:00/w/CHAOSS%20Value%20WG#eyJ1cmwiOiJodHRwczovL3Vub21haGEuem9vbS51cy9qLzcyMDQzMTI4OCJ9)) via [Zoom](https://unomaha.zoom.us/j/720431288). -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1qWAV4ExtwcY3mSzIb9sYOUENt4Pi1BD7APjnRTCnZZs/edit?ts=5c9a8e98)
+
+Info about working group: [https://github.com/chaoss/wg-value](https://github.com/chaoss/wg-value)


### PR DESCRIPTION
Updated the information about the Value WG. https://github.com/chaoss/wg-value/issues/9

- [ ] _Home_: Add a bullet item for "Value"
- [x] _About_: Add a bullet item for "Value Metrics WG"
- [x] _Metrics Page_: Use the existing content as a template for a "Value Metrics" block
- [x] _Participate Page_: Use the Common Metrics content as a template for a "Value Metrics" block

I couldn't find the _Home Page_ to add a bullet item for "Value". I thought this would be the file, https://github.com/chaoss/website/blob/master/Home/about-us.md but I cannot see any items.

Is the _Home Page_ managed by Wordpress or am I mistaken?

Can anyone help me with this?

If you need any changes, I am ready to make them. :slightly_smiling_face: 