### PR TITLE
add link to CHAOSSconNA'19

### DIFF
--- a/CHAOSScon/past-future.md
+++ b/CHAOSScon/past-future.md
@@ -1,6 +1,6 @@
 ## Upcoming CHAOSScon events
 
-* **CHAOSScon 2019 North America**, August 20th, 2019, San Diego, California, co-located with Open Source Summit 2019.
+* [**CHAOSScon 2019 North America**](https://chaoss.community/chaosscon-2019-na/), August 20th, 2019, San Diego, California, co-located with Open Source Summit 2019.
 * **CHAOSScon 2020 Europe**, TBA, Brussels, Belgium, co-located with FOSDEM 2020.
 
 ## Past CHAOSScon events


### PR DESCRIPTION
When the CHAOSSconNA'19 link is added to the website menu, this pull request will add the link to the bottom of all other CHAOSScon pages.

- [ ] Add CHAOSScon to menu
- [ ] Replace button on home page "join a WG" to point to the conference page and read something like "Join us August 20 in San Diego for CHAOSScon"