### PR TITLE
Add Blogpost: CHAOSS D&I WG on The New Stack

### DIFF
--- a/Community/News/20190514_tns_blog_podcast.md
+++ b/Community/News/20190514_tns_blog_podcast.md
@@ -1,0 +1,25 @@
+# CHAOSS D&I WG on The New Stack
+
+A [contributed article on The New Stack](https://thenewstack.io/how-chaoss-di-can-help-diversity-in-the-open-source-community/) details how the CHAOSS D&I Working Group got started and evolved. Georg Link and Sarah Conway take a close look at working group's history and capture insights that are only known to those who were part of the evolution. The article outline is:
+
+* History of the CHAOSS project
+* Rise of the CHAOSS D&I Working Group
+* Creating D&I Metrics
+* What’s Next for CHAOSS D&I WG
+
+The New Stack staff also interviewed Georg Link and Nicole Huesman about the CHAOSS D&I Working Group for their [podcast](https://thenewstack.io/how-chaoss-measures-diversity-windows-gets-a-proper-terminal/). Questions they answer are:
+
+* How did you get involved with the CHAOSS project?
+* How did the CHAOSS project come about? Why was the Linux Foundation interested in creating a standard set of metrics for open source projects?
+* What were the initial metrics that people were interested in in measuring? What were they trying to learn about their projects that fueled that initial interest?
+* What are the questions and metrics that you would use to quantify diversity and inclusion?
+* How is CHAOSS measuring results of diversity and inclusion? What are good metrics to use as indicators?
+* What is the plan for getting diversity and inclusion metrics out to individual projects and supporting them with using the metrics?
+* Why do people want metrics? What do they want to use them for? How does it improve software delivery?
+* How to get involved in the CHAOSS project?
+
+**Links:**
+
+Contributed article on The New Stack: https://thenewstack.io/how-chaoss-di-can-help-diversity-in-the-open-source-community/
+
+Podcast on The New Stack: https://thenewstack.io/how-chaoss-measures-diversity-windows-gets-a-proper-terminal/

--- a/Community/News/20190514_tns_blog_podcast.md
+++ b/Community/News/20190514_tns_blog_podcast.md
@@ -1,6 +1,6 @@
 # CHAOSS D&I WG on The New Stack
 
-A [contributed article on The New Stack](https://thenewstack.io/how-chaoss-di-can-help-diversity-in-the-open-source-community/) details how the CHAOSS D&I Working Group got started and evolved. Georg Link and Sarah Conway take a close look at working group's history and capture insights that are only known to those who were part of the evolution. The article outline is:
+A [contributed article on The New Stack](https://thenewstack.io/how-chaoss-di-can-help-diversity-in-the-open-source-community/) details how the CHAOSS D&I Working Group got started and evolved. Georg Link and Sarah Conway take a close look at the working group's history and capture insights that are only known to those who were part of the evolution. The article outline is:
 
 * History of the CHAOSS project
 * Rise of the CHAOSS D&I Working Group
@@ -11,7 +11,7 @@ The New Stack staff also interviewed Georg Link and Nicole Huesman about the CHA
 
 * How did you get involved with the CHAOSS project?
 * How did the CHAOSS project come about? Why was the Linux Foundation interested in creating a standard set of metrics for open source projects?
-* What were the initial metrics that people were interested in in measuring? What were they trying to learn about their projects that fueled that initial interest?
+* What were the initial metrics that people were interested in measuring? What were they trying to learn about their projects that fueled that initial interest?
 * What are the questions and metrics that you would use to quantify diversity and inclusion?
 * How is CHAOSS measuring results of diversity and inclusion? What are good metrics to use as indicators?
 * What is the plan for getting diversity and inclusion metrics out to individual projects and supporting them with using the metrics?


### PR DESCRIPTION
This pr is to add a blog post to the CHAOSS community blog.

The blog post is about featuring the recent The New Stack contributed article and podcast.

If possible, it would be great to embed SoundCloud recording to allow listening to the podcast right from our blog.

    <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/618738513&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>