### PR TITLE
Update working-groups.md

### DIFF
--- a/Home/working-groups.md
+++ b/Home/working-groups.md
@@ -4,7 +4,7 @@ The goal of the working groups is to refine the metrics and to work with softwar
 
 The working groups are:  
 [Common Metrics](https://github.com/chaoss/metrics)   
-[Diversity and Inclusion](https://github.com/chaoss/wg-evolution)  
-[Evolution](https://github.com/chaoss/wg-gmd)  
+[Diversity and Inclusion](https://github.com/chaoss/wg-diversity-inclusion
+[Evolution](https://github.com/chaoss/wg-evolution)  
 [Risk](https://github.com/chaoss/wg-risk)  
 [Value](https://github.com/chaoss/wg-value)  


### PR DESCRIPTION
The link for Diversity and Inclusion working group was pointed at the "Evolution" working-group.  This proposed change corrects that.