### PR TITLE
add software WG for /participate page

### DIFF
--- a/Participate/software-augur.md
+++ b/Participate/software-augur.md
@@ -1,0 +1,7 @@
+### Augur
+
+This Working Group connects the Augur software development with metrics work in other CHAOSS working groups. Topics including how-to's, technology, roadmap, implementation, architecture, and metric visualization.
+
+The Augur Working Group meets every Tuesday at 10am CT (usually 17 CET, [check your local time](https://www.arewemeetingyet.com/Chicago/2019-09-18/10:00/w//CHAOSS%20Augur%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1zo53hswG_ck9kC5vxVIHHNGHdSr4D3mie0lpXjoGH70/edit)
+
+Info about Augur: [https://github.com/chaoss/augur](https://github.com/chaoss/augur)

--- a/Participate/software-dashboard.md
+++ b/Participate/software-dashboard.md
@@ -4,4 +4,4 @@ The community dashboard at [chaoss.biterg.io](chaoss.biterg.io) is a GrimoireLab
 
 CHAOSS community members can create, save, and share visualizations. This is encouraged in building out metrics within working groups.
 
-To request access, message [Quan Zhou](https://keybase.io/quanzh) through [Keybase](keybase.io). This allows encrypted and secure transmission of the login information.
+To request access, please [open an issue](https://gitlab.com/Bitergia/c/CHAOSS/support/issues/new?issue%5Btitle=request%20access%20to%20chaoss.biterg.io&issue%5Bdescription=I%20would%20like%20access%20to%20the%20CHAOSS%20dashboard%20at%20chaoss.biterg.io%20Please%20send%20credentials%20to%20my%20Keybase%20account%20_____%20.) and include your [Keybase](keybase.io) name to allow secure transmission of the login information.

--- a/Participate/software-dashboard.md
+++ b/Participate/software-dashboard.md
@@ -1,0 +1,7 @@
+### Community Dashboard
+
+The community dashboard at [chaoss.biterg.io](chaoss.biterg.io) is a GrimoireLab instance provided by [Bitergia](www.bitergia.com). All contributors' information in the CHAOSS project is processed to power the dashboard. 
+
+CHAOSS community members can create, save, and share visualizations. This is encouraged in building out metrics within working groups.
+
+To request access, message [Quan Zhou](https://keybase.io/quanzh) through [Keybase](keybase.io). This allows encrypted and secure transmission of the login information.

--- a/Participate/software-grimoirelab.md
+++ b/Participate/software-grimoirelab.md
@@ -1,0 +1,7 @@
+### GrimoireLab
+
+This Working Group connects the GrimoireLab software development with metrics work in other CHAOSS working groups. Topics including how-to's, technology, roadmap, implementation, architecture, and metric visualization.
+
+The GrimoireLab Working Group meets every Tuesday at 10am CT (usually 17 CET, [check your local time](https://arewemeetingyet.com/Chicago/2019-09-03/10:00/w/CHAOSS%20GrimoireLab%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/19CNl6J0YqVrRKFy1SuSybiKaWIY8yGkrMbuzJ3q8f_s/edit)
+
+Info about GrimoireLab: [https://github.com/chaoss/grimoirelab](https://github.com/chaoss/grimoirelab)


### PR DESCRIPTION
We have two additional calls every week for CHAOSS Software.

I propose that we add the information on the /participate page.

To stay within the 3-column format that we have, we can use the third slot for information about how to request access to the CHAOSS community dashboard at chaoss.biterg.io.
This would also server as the GDPR compliant disclaimer that community participation is processed by Biterga as the data owner behind the dashboard. 

/cc @sanacl and @dicortazar  does the information satisfy the GDPR requirements?

/cc @dicortazar and @alpgarcia since you are maintainers of the GrimoireLab WG, does the information work for you?

/cc @ccarterlandis and @sgoggins sinc eyou are maintainers of the Augur WG, does the information work for you?