### PR TITLE
fix Evolution WG timing on /participate page

### DIFF
--- a/Participate/growth-maturity-decline-weekly-call.md
+++ b/Participate/growth-maturity-decline-weekly-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on Evolution metrics and software. The goal is to refine the metrics that inform Evolution and to work with software implementations.
 
-The Evolution working group meets every other Wednesday at 9:30am CT (usually 16:30 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-04-24/09:30/b/CHAOSS%20Evolution%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1fgMT5onwvNQE6b4gPWE7oSPHRvb9q1z6XEbD51EtCFg/edit)
+The Evolution working group meets every other Thursday at 10:00am CT (usually 17:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-10-10/10:00/b/CHAOSS%20Evolution%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1fgMT5onwvNQE6b4gPWE7oSPHRvb9q1z6XEbD51EtCFg/edit)
 
 Info about working group: [https://github.com/chaoss/wg-evolution](https://github.com/chaoss/wg-evolution)


### PR DESCRIPTION
The time of the Evolution WG was wrong on the /participate page. This PR fixes it.