### PR TITLE
fix risk call time on /participate page

### DIFF
--- a/Participate/risk-call.md
+++ b/Participate/risk-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on Compliance and Risk metrics. The goal is to refine the metrics that inform Risk and to work with software implementations.
 
-The Risk working group meets every other Monday at 1:00pm CT (usually 20:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-04-15/13:00/w/CHAOSS%20Risk%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1iqIMpLBwuKSnE0BbQTgbsb9Im87IoN7IUzukochClCw/edit)
+The Risk working group meets every other Monday at 1:00pm CT (usually 18:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-10-07/13:00/w/CHAOSS%20Risk%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1iqIMpLBwuKSnE0BbQTgbsb9Im87IoN7IUzukochClCw/edit)
 
 Info about working group: [https://github.com/chaoss/wg-risk](https://github.com/chaoss/wg-risk)


### PR DESCRIPTION
1. The European time was wrong
2. The link for checking the next meeting was off by one week