### PR TITLE
Update release-notes.md

### DIFF
--- a/release/release-notes.md
+++ b/release/release-notes.md
@@ -7,47 +7,56 @@ Download PDF of previous release:
 - [Release 201908](https://chaoss.github.io/website/release/201908/CHAOSS-Metrics-Release-201908.pdf)
 
 ## Release 202001 Notes:
+[PDF of released CHAOSS Metrics (v.201908)](https://chaoss.github.io/website/release/202001/CHAOSS-Metrics-Release-202001.pdf)
 
-*All Metrics were restructured to conform to the new CHAOSS Project metrics document structure.*
+All Metrics were restructured to conform to the new CHAOSS Project metrics document structure.
 
 **Common**
 * New metrics include:
-  * Activity Dates and Times
-  * Time to First Response
-  *	Contributors
+  - Activity Dates and Times
+  - Time to First Response
+  -	Contributors
 * Restructured and renamed focus areas
 * Organizational Diversity remains unchanged from previous release.
 
 **Diversity & Inclusion**
 * New metrics include:
-  * Sponsorship
-  * Board/Council Diversity
+  - Sponsorship
+  - Board/Council Diversity
 * Improved clarity on several metrics that were in the previous release
 
 **Evolution**
 * New metrics include:
-  * Issue Age
-  *	Issue Response Time
-  *	Issue Resolution Duration
-  *	New Contributors Closing Issues
-*	Updated focus areas. Refactored the "Code Development" focus area into 3 separate focus areas to more closely align with other working groups. Rather than having one broad focus area with multiple subsections, we decided our intent would be better communicated by making each of these subsections into their own focus areas. The 3 separate focus areas include:
-  * Code Development Activity
-  * Code Development Efficiency
-  * Code Development Process Quality
+  - Issue Age
+  -	Issue Response Time
+  -	Issue Resolution Duration
+  -	New Contributors Closing Issues
+*	Updated focus areas. 
+  Refactored the "Code Development" focus area into 3 separate focus areas to more closely align with other working groups. Rather than having one broad focus area with multiple subsections, we decided our intent would be better communicated by making each of these subsections into their own focus areas.
+  The 3 separate focus areas include:
+    - Code Development Activity
+    - Code Development Efficiency
+    - Code Development Process Quality
 * Kept the other 2 focus areas (Issue Resolution and Community Growth) the same.
 * No major changes were made to already existing metrics.
 
 **Risk**
 * New metrics include:
-  * OSI Approved Licenses
-  *	Licenses Declared
-  *	Test Coverage (Updated)
-  *	Elephant Factor
-  *	Committers
+  - OSI Approved Licenses
+  -	Licenses Declared
+  -	Test Coverage (Updated)
+  -	Elephant Factor
+  -	Committers
 * Focused on increasing metrics coverage in the general areas of CNCF Core Infrastructure badging and licensing.
 
 **Value**
 * New metrics include:
-  * Social Currency Metric System (SCMS)
-  * Job Opportunities
+  - Social Currency Metric System (SCMS)
+  - Job Opportunities
 * A new focus area of Ecosystem Value was developed
+
+## Release 201908 Notes
+[PDF of released CHAOSS Metrics (v.201908)](https://chaoss.github.io/website/release/201908/CHAOSS-Metrics-Release-201908.pdf)
+
+Initial CHAOSS Metrics release.
+


### PR DESCRIPTION
fix bullet item level
add Release 201908 Notes
add a PDF download under each release heading

I am not convinced that having the PDF's at the top is helpful. I think it is enough to have a PDF download link with each release heading. I did not remove the part at the top thought, this is my comment.