### PR TITLE
make release-notes smaller

### DIFF
--- a/release/release-notes.md
+++ b/release/release-notes.md
@@ -1,8 +1,7 @@
 # Release History
 
 ## Release 202001 Notes:
-[PDF of released CHAOSS Metrics (v.201908)](https://chaoss.github.io/website/release/202001/CHAOSS-Metrics-Release-202001.pdf)
-
+- [PDF of released CHAOSS Metrics (v.201908)](https://chaoss.github.io/website/release/202001/CHAOSS-Metrics-Release-202001.pdf)
 - All Metrics were restructured to conform to the new CHAOSS Project metrics document structure.
 - **Common WG**
   * New metrics include:
@@ -45,7 +44,6 @@
   * A new focus area of Ecosystem Value was developed
 
 ## Release 201908 Notes
-[PDF of released CHAOSS Metrics (v.201908)](https://chaoss.github.io/website/release/201908/CHAOSS-Metrics-Release-201908.pdf)
-
-Initial CHAOSS Metrics release.
+- [PDF of released CHAOSS Metrics (v.201908)](https://chaoss.github.io/website/release/201908/CHAOSS-Metrics-Release-201908.pdf)
+- Initial CHAOSS Metrics release.
 

--- a/release/release-notes.md
+++ b/release/release-notes.md
@@ -1,59 +1,48 @@
 # Release History
 
-Download PDF of Current release:
-- [Release 202001](https://chaoss.github.io/website/release/202001/CHAOSS-Metrics-Release-202001.pdf)
-
-Download PDF of previous release:
-- [Release 201908](https://chaoss.github.io/website/release/201908/CHAOSS-Metrics-Release-201908.pdf)
-
 ## Release 202001 Notes:
 [PDF of released CHAOSS Metrics (v.201908)](https://chaoss.github.io/website/release/202001/CHAOSS-Metrics-Release-202001.pdf)
 
-All Metrics were restructured to conform to the new CHAOSS Project metrics document structure.
-
-**Common**
-* New metrics include:
-  - Activity Dates and Times
-  - Time to First Response
-  -	Contributors
-* Restructured and renamed focus areas
-* Organizational Diversity remains unchanged from previous release.
-
-**Diversity & Inclusion**
-* New metrics include:
-  - Sponsorship
-  - Board/Council Diversity
-* Improved clarity on several metrics that were in the previous release
-
-**Evolution**
-* New metrics include:
-  - Issue Age
-  -	Issue Response Time
-  -	Issue Resolution Duration
-  -	New Contributors Closing Issues
-*	Updated focus areas. 
-  Refactored the "Code Development" focus area into 3 separate focus areas to more closely align with other working groups. Rather than having one broad focus area with multiple subsections, we decided our intent would be better communicated by making each of these subsections into their own focus areas.
-  The 3 separate focus areas include:
-    - Code Development Activity
-    - Code Development Efficiency
-    - Code Development Process Quality
-* Kept the other 2 focus areas (Issue Resolution and Community Growth) the same.
-* No major changes were made to already existing metrics.
-
-**Risk**
-* New metrics include:
-  - OSI Approved Licenses
-  -	Licenses Declared
-  -	Test Coverage (Updated)
-  -	Elephant Factor
-  -	Committers
-* Focused on increasing metrics coverage in the general areas of CNCF Core Infrastructure badging and licensing.
-
-**Value**
-* New metrics include:
-  - Social Currency Metric System (SCMS)
-  - Job Opportunities
-* A new focus area of Ecosystem Value was developed
+- All Metrics were restructured to conform to the new CHAOSS Project metrics document structure.
+- **Common WG**
+  * New metrics include:
+    - Activity Dates and Times
+    - Time to First Response
+    -	Contributors
+  * Restructured and renamed focus areas
+  * Organizational Diversity remains unchanged from previous release.
+- **Diversity & Inclusion WG**
+  * New metrics include:
+    - Sponsorship
+    - Board/Council Diversity
+  * Improved clarity on several metrics that were in the previous release
+- **Evolution WG**
+  * New metrics include:
+    - Issue Age
+    -	Issue Response Time
+    -	Issue Resolution Duration
+    -	New Contributors Closing Issues
+  *	Updated focus areas. 
+    Refactored the "Code Development" focus area into 3 separate focus areas to more closely align with other working groups. Rather than having one broad focus area with multiple subsections, we decided our intent would be better communicated by making each of these subsections into their own focus areas.
+    The 3 separate focus areas include:
+      - Code Development Activity
+      - Code Development Efficiency
+      - Code Development Process Quality
+  * Kept the other 2 focus areas (Issue Resolution and Community Growth) the same.
+  * No major changes were made to already existing metrics.
+- **Risk WG**
+  * New metrics include:
+    - OSI Approved Licenses
+    -	Licenses Declared
+    -	Test Coverage (Updated)
+    -	Elephant Factor
+    -	Committers
+  * Focused on increasing metrics coverage in the general areas of CNCF Core Infrastructure badging and licensing.
+- **Value WG**
+  * New metrics include:
+    - Social Currency Metric System (SCMS)
+    - Job Opportunities
+  * A new focus area of Ecosystem Value was developed
 
 ## Release 201908 Notes
 [PDF of released CHAOSS Metrics (v.201908)](https://chaoss.github.io/website/release/201908/CHAOSS-Metrics-Release-201908.pdf)


### PR DESCRIPTION
I removed the PDFs at the top because they are not the most important item and they are also available under each release below.

I turned the release notes all into one gigantic bullet list to remove whitespace and make them more compact. I was overwhelmed by how long the release notes were. A wall of bullet points is probably not much better, but it should make feel everything part of one release. Only the headings are now surrounded by whitespace, making scrolling easier.

This is only a proposal. Feel free to reject.