### PR TITLE
fix broken link on homepage

### DIFF
--- a/Home/about-us.md
+++ b/Home/about-us.md
@@ -1,5 +1,5 @@
 CHAOSS is a Linux Foundation project focused on creating analytics and metrics to help define community health. [Learn More](https://chaoss.community/about/)
 
-Get to know the [CHAOSS community](https://chaoss.community/community/)
+Get to know the CHAOSS community
 and
 learn how to [participate](https://chaoss.community/participate/).


### PR DESCRIPTION
The /community page disappeared. This pr removes a broken link on the home page.