### PR TITLE
change D&I meeting time to Wednesday

### DIFF
--- a/Participate/diversity-inclusion-workgroup-weekly-call.md
+++ b/Participate/diversity-inclusion-workgroup-weekly-call.md
@@ -2,7 +2,7 @@
 
 This working group aims at bringing together experiences measuring diversity and inclusion in open source projects. Its main goal focuses on understanding from a qualitative and quantitative point of view how diversity and inclusion can be measured.
 
-The D&I working group meets every Monday at 11:00am CT (usually 18:00 CET, [check your local time](https://arewemeetingyet.com/Chicago/2019-11-04/11:00/w/CHAOSS%20D%26I%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit)
+The D&I working group meets every Wednesday at 10:00am CT (usually 17:00 CET, [check your local time](https://arewemeetingyet.com/Chicago/2020-02-10/10:00/w/CHAOSS%20D%26I%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit)
 
 Info about working group: https://github.com/chaoss/wg-diversity-inclusion
 


### PR DESCRIPTION
CHAOSS D&I WG will be meeting on Wednesdays starting next week. This PR updates our Participate page.