### PR TITLE
update meeting day and time of Value WG

### DIFF
--- a/Participate/value-call.md
+++ b/Participate/value-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on industry-standard metrics for economic value in open source. The main goal is to publish trusted industry-standard Value Metrics. A kind of S&P for software development, an authoritative source for metrics significance and industry norms.
 
-The Value working group meets every other Friday at 11:00am CT (usually 17:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-10-25/11:00/b/CHAOSS%20Value%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1qWAV4ExtwcY3mSzIb9sYOUENt4Pi1BD7APjnRTCnZZs/edit#heading=h.bdn0grlsbx6)
+The Value working group meets every other Thursday at 10:00am CT (usually 16:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2020-02-27/10:00/b/CHAOSS%20Value%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1qWAV4ExtwcY3mSzIb9sYOUENt4Pi1BD7APjnRTCnZZs/edit#heading=h.bdn0grlsbx6)
 
 Info about working group: [https://github.com/chaoss/wg-value](https://github.com/chaoss/wg-value)


### PR DESCRIPTION
The Value WG is moving to Thursdays 10am CST in the same time-slot as Common WG but one week removed.

This PR makes the update on the /participate page.