### PR TITLE
fix "check your local time" for D&I WG

### DIFF
--- a/Participate/diversity-inclusion-workgroup-weekly-call.md
+++ b/Participate/diversity-inclusion-workgroup-weekly-call.md
@@ -2,7 +2,7 @@
 
 This working group aims at bringing together experiences measuring diversity and inclusion in open source projects. Its main goal focuses on understanding from a qualitative and quantitative point of view how diversity and inclusion can be measured.
 
-The D&I working group meets every Wednesday at 10:00am CT (usually 17:00 CET, [check your local time](https://arewemeetingyet.com/Chicago/2020-02-10/10:00/w/CHAOSS%20D%26I%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit)
+The D&I working group meets every Wednesday at 10:00am CT (usually 17:00 CET, [check your local time](https://arewemeetingyet.com/Chicago/2020-05-27/10:00/w/CHAOSS%20D%26I%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit)
 
 Info about working group: https://github.com/chaoss/wg-diversity-inclusion
 


### PR DESCRIPTION
The link was still for Monday's, but we are meeting on Wednesdays