### PR TITLE
add gsoc-acceptance-venu blog post

### DIFF
--- a/Community/News/20200530_gsoc-acceptance-venu.md
+++ b/Community/News/20200530_gsoc-acceptance-venu.md
@@ -1,0 +1,69 @@
+# GSoC Acceptance 
+
+by [Venu Vardhan Reddy Tekula](https://vchrombie.github.io/)
+
+_originally published on May 6th 2020 at [vchrombie.github.io/blog/gsoc-acceptance](https://vchrombie.github.io/blog/gsoc-acceptance)._  
+
+
+Hello!
+
+> Hi vchrombie,
+>
+> Your proposal Creating Quality models using GrimoireLab and CHAOSS metrics has been accepted!
+>
+> Welcome to GSoC 2020!
+>
+> We look forward to seeing the great things you will accomplish this summer with CHAOSS.
+
+Yes, I got selected for the Google Summer of Code 2020 program. 🥳
+
+The first time I heard about this program was during my first year. Later, I tried applying in my second and third year but 
+I couldn't make it through. This is my final year and was probably my last chance to apply. I didn't take it easy this time. 
+I collected the feedback and analyzed the mistakes I did in the previous years. I started off early, contributing and
+preparing a proposal for the project.
+
+It has been more than a year since I was involved with CHAOSS. I applied last year too but I didn't get selected. 
+But, I didn't stop involving with the community. I sticked around, contributing to their projects and participating with 
+the community activities. This time, I decided to go with the same organization as I saw some pretty good ideas in the list. 
+I selected an idea, Creating Quality models using GrimoireLab and CHAOSS metrics ([chaoss/grimoirelab#287](https://github.com/chaoss/grimoirelab/issues/287)).
+
+I was already kinda familiar with the procedure of CHAOSS. The applicants are expected to work on the microtasks, 
+parallely making some good initial contributions and working on the proposal. The mentors are always helpful to get you 
+started with the contributions and helping & reviewing the microtasks. I started doing the microtasks by the first week of 
+February, doing some contributions along the way. Link to the microtasks repository, [vchrombie/chaoss-microtasks](https://github.com/vchrombie/chaoss-microtasks).
+
+There were a lot of improvements to the GrimoireLab during the application period. Some of the main contributions in which I was involved are
+- Made a script to automate some part of the dev env setup of GrimoireLab, [glab-dev-env-setup.py](https://gist.github.com/vchrombie/4403193198cd79e7ee0079259311f6e8).
+- Made a video on how to setup Prosoul, [Setting up Prosoul | YouTube](https://www.youtube.com/watch?v=-wU1ck4ZrUw).
+- Involved with a major revamp of [Getting Started Tutorial](https://github.com/chaoss/grimoirelab-sirmordred/blob/master/Getting-Started.md) of the SirMordred tool.
+- Improvements and bug fixes in Prosoul, [contributions](https://github.com/Bitergia/prosoul/pulls?q=is%3Apr+author%3Avchrombie).
+- Made a tool to update the licenses of the code files in the repository, ([vchrombie/reparo](https://github.com/vchrombie/reparo)). Tested it on a few huge repositories like perceval and graal.
+
+You can find all the contributions here, [vchrombie/chaoss-microtasks#10](https://github.com/vchrombie/chaoss-microtasks/blob/master/microtask-10/README.md). 
+
+The next step was the proposal. [Valerio](http://valeriocos.github.io/) helped a lot with the understanding of the project 
+idea. I had a pretty good understanding of the project as he cleared most of the doubts. You can go through my proposal, 
+[gsoc-proposal-venu.pdf](https://github.com/vchrombie/gsoc/blob/master/notes/gsoc-proposal-venu.pdf).
+
+After submitting the application, I was just waiting with my fingers crossed. 🤞
+
+![gsoc-submission](https://user-images.githubusercontent.com/25265451/83336383-9ed6dc80-a2d0-11ea-8ee0-eb17329de3de.png)
+
+Meanwhile, I proposed the participation of CHAOSS in the Google Summer of Docs 2020 program. We managed to get a chance to 
+apply on behalf of the Linux Foundation and we collected a total of 5 ideas for the program, 
+[gsod-2020-chaoss-ideas](https://wiki.linuxfoundation.org/gsoc/2020-gsod-chaoss).
+
+The results day, May 4th has arrived. I got selected with eight other GSoC students from CHAOSS and one Outreachy student. 
+I was happy about it. There are two students from the GrimoireLab project, one being me and the other one was 
+[Ria Gupta](https://github.com/ria18405). Ria will be working on another idea, Implement the Social Currency Metrics System 
+in GrimoireLab ([chaoss/grimoirelab#288](https://github.com/chaoss/grimoirelab/issues/288)).
+
+![gsoc-project-page](https://user-images.githubusercontent.com/25265451/83336384-a0080980-a2d0-11ea-9a4e-5e2bdbe6e205.png)
+
+The idea of the project is to create simple software quality models using Prosoul, the GrimoireLab data and the 
+CHAOSS metrics. You can read more about the project from here, https://summerofcode.withgoogle.com/projects/#5489558193438720.
+
+Check out my [blog](https://vchrombie.github.io/blog/) or follow me on [Twitter](https://twitter.com/vchrombie) for more 
+updates.
+
+Cheers to another fantastic summer coming up next. 😃


### PR DESCRIPTION
Hi @klumb 

I thought of publishing my gsoc-acceptance blog post on the CHAOSS website. I had this thing in my head for a long time. Finally, I could grab some time for this.

I have added the blog post, content everything as per the instructions. Please let me know if I did anything wrong.

Also, I have published this blog post on my personal blog, https://vchrombie.github.io/blog/gsoc-acceptance. If you feel that the content needs some editing to go onto the CHAOSS website, please feel free to suggest any changes. :smiley:

cc @GeorgLink