### PR TITLE
Adds new zoom link

### DIFF
--- a/Participate/Asia-Pacific-community-call.md
+++ b/Participate/Asia-Pacific-community-call.md
@@ -3,4 +3,4 @@
 
 This working group aims to connect with community members in the Asia Pacific region regarding open source community health. Discussions will focus on recapping CHAOSS work as well as identifying new areas of interest. The working group is, of course, open to everyone from any global region.
 
-The Asia Pacific community call meets every other Wednesday at 8:00am CST (usually 21:00 UTC+8, [check your local time](https://arewemeetingyet.com/Chicago/2020-06-17/08:00/b/CHAOSS%20Asia%20Pacific%20Community%20Call)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/17S89h-0MpMA0fzkxv16LRgK8Nh1Qov7lammjNnPk16E/edit)
+The Asia Pacific community call meets every other Wednesday at 8:00am CST (usually 21:00 UTC+8, [check your local time](https://arewemeetingyet.com/Chicago/2020-06-17/08:00/b/CHAOSS%20Asia%20Pacific%20Community%20Call)) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/17S89h-0MpMA0fzkxv16LRgK8Nh1Qov7lammjNnPk16E/edit)

--- a/Participate/app-ecosystem-call.md
+++ b/Participate/app-ecosystem-call.md
@@ -2,4 +2,4 @@
 
 This working group applies CHAOSS metrics in the context of an open source app ecosystem. The mission of this working group is to build a base set of metrics that is focused on the needs of open source communities that are part of the FOSS app ecosystem.
 
-The App Ecosystem working group call meets every other Monday at 12:00pm CST (usually 19:00 CET), [check your local time](check your local time: https://arewemeetingyet.com/Chicago/2020-04-06/12:00/b/CHAOSS%20WG:%20App%20Ecosystem) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1HABrco2NGhchPLHK_PvKRsFHEU0fMfpnn0Axacv-OX8/edit)
+The App Ecosystem working group call meets every other Monday at 12:00pm CST (usually 19:00 CET), [check your local time](check your local time: https://arewemeetingyet.com/Chicago/2020-04-06/12:00/b/CHAOSS%20WG:%20App%20Ecosystem) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1HABrco2NGhchPLHK_PvKRsFHEU0fMfpnn0Axacv-OX8/edit)

--- a/Participate/chaoss-weekly-and-monthly-calls.md
+++ b/Participate/chaoss-weekly-and-monthly-calls.md
@@ -1,7 +1,7 @@
 ### CHAOSS Community
 The first Tuesday every month is a formal 'monthly call' for updates from committees, working groups, and broader community. All other Tuesdays, we 'hangout' informally without agenda. Topics include new metrics, how to interpret metrics, progress on software development, new features that would be nice, recaps from recent events, or community questions.
 
-The CHAOSS community meets every Tuesday at 11am CT (usually 18:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-06/11:00/w/CHAOSS%20weekly%20community%20meeting)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1PMDWc6xMe0fNE7shxTK5_HE_ykRBG5w55_Zx5hvzsEY/edit)
+The CHAOSS community meets every Tuesday at 11am CT (usually 18:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2018-11-06/11:00/w/CHAOSS%20weekly%20community%20meeting)) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1PMDWc6xMe0fNE7shxTK5_HE_ykRBG5w55_Zx5hvzsEY/edit)
 
 <a href="https://chaoss.github.io/website/Participate/CHAOSS-Calendar_WeeklySync.ics">Add to calendar (ICS file)</a>.
 

--- a/Participate/common-metrics.md
+++ b/Participate/common-metrics.md
@@ -2,6 +2,6 @@
 
 The Common Metrics Working Group focuses on defining the metrics that are used by both working groups or are important for community health, but that do not cleanly fit into one of the other existing working groups. Areas of interest include organizational affiliation, responsiveness, and geographic coverage.
 
-The Common Metrics WG meets every other Thursday at 10:00am CT (usually 17:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-02-21/10:00/b/CHAOSS%20Common%20Metrics%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://bit.ly/2ROytFz)
+The Common Metrics WG meets every other Thursday at 10:00am CT (usually 17:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-02-21/10:00/b/CHAOSS%20Common%20Metrics%20WG)) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://bit.ly/2ROytFz)
 
 Info about working group: [https://github.com/chaoss/wg-common](https://github.com/chaoss/wg-common)

--- a/Participate/diversity-inclusion-workgroup-weekly-call.md
+++ b/Participate/diversity-inclusion-workgroup-weekly-call.md
@@ -2,7 +2,7 @@
 
 This working group aims to bring together experiences measuring diversity and inclusion in open source projects. Its main goal focuses on understanding from a qualitative and quantitative point of view how diversity and inclusion can be measured.
 
-The D&I working group meets every Wednesday at 10:00am CT (usually 17:00 CET, [check your local time](https://arewemeetingyet.com/Chicago/2020-05-27/10:00/w/CHAOSS%20D%26I%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit)
+The D&I working group meets every Wednesday at 10:00am CT (usually 17:00 CET, [check your local time](https://arewemeetingyet.com/Chicago/2020-05-27/10:00/w/CHAOSS%20D%26I%20WG)) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit)
 
 Info about working group: https://github.com/chaoss/wg-diversity-inclusion
 

--- a/Participate/growth-maturity-decline-weekly-call.md
+++ b/Participate/growth-maturity-decline-weekly-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on Evolution metrics and software. The goal is to refine the metrics that inform Evolution and to work with software implementations.
 
-The Evolution working group meets every other Wednesday at 9:00am CT (usually 16:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-10-10/10:00/b/CHAOSS%20Evolution%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1fgMT5onwvNQE6b4gPWE7oSPHRvb9q1z6XEbD51EtCFg/edit)
+The Evolution working group meets every other Wednesday at 9:00am CT (usually 16:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-10-10/10:00/b/CHAOSS%20Evolution%20WG)) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1fgMT5onwvNQE6b4gPWE7oSPHRvb9q1z6XEbD51EtCFg/edit)
 
 Info about working group: [https://github.com/chaoss/wg-evolution](https://github.com/chaoss/wg-evolution)

--- a/Participate/risk-call.md
+++ b/Participate/risk-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on Compliance and Risk metrics. The goal is to refine the metrics that inform Risk and to work with software implementations.
 
-The Risk working group meets every other Monday at 9:00am CT (usually 16:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-12-09/09:00/b/CHAOSS%20Risk%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1iqIMpLBwuKSnE0BbQTgbsb9Im87IoN7IUzukochClCw/edit)
+The Risk working group meets every other Monday at 9:00am CT (usually 16:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2019-12-09/09:00/b/CHAOSS%20Risk%20WG)) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1iqIMpLBwuKSnE0BbQTgbsb9Im87IoN7IUzukochClCw/edit)
 
 Info about working group: [https://github.com/chaoss/wg-risk](https://github.com/chaoss/wg-risk)

--- a/Participate/software-augur.md
+++ b/Participate/software-augur.md
@@ -2,6 +2,6 @@
 
 This Working Group connects the Augur software development with metrics work in other CHAOSS working groups. Topics including how-to's, technology, roadmap, implementation, architecture, and metric visualization.
 
-The Augur Working Group meets every Thursday at 9:00am CT (usually 14:00 CET, [check your local time](https://arewemeetingyet.com/Chicago/2019-10-23/13:00/w/Augur%20WG%20Meeting)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1zo53hswG_ck9kC5vxVIHHNGHdSr4D3mie0lpXjoGH70/edit)
+The Augur Working Group meets every Thursday at 9:00am CT (usually 14:00 CET, [check your local time](https://arewemeetingyet.com/Chicago/2019-10-23/13:00/w/Augur%20WG%20Meeting)) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1zo53hswG_ck9kC5vxVIHHNGHdSr4D3mie0lpXjoGH70/edit)
 
 Info about Augur: [https://github.com/chaoss/augur](https://github.com/chaoss/augur)

--- a/Participate/value-call.md
+++ b/Participate/value-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on industry-standard metrics for economic value in open source. The main goal is to publish trusted industry-standard Value Metrics. A kind of S&P for software development, an authoritative source for metrics significance and industry norms.
 
-The Value working group meets every other Thursday at 10:00am CT (usually 16:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2020-02-27/10:00/b/CHAOSS%20Value%20WG)) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1qWAV4ExtwcY3mSzIb9sYOUENt4Pi1BD7APjnRTCnZZs/edit#heading=h.bdn0grlsbx6)
+The Value working group meets every other Thursday at 10:00am CT (usually 16:00 CET, [check your local time](http://arewemeetingyet.com/Chicago/2020-02-27/10:00/b/CHAOSS%20Value%20WG)) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1qWAV4ExtwcY3mSzIb9sYOUENt4Pi1BD7APjnRTCnZZs/edit#heading=h.bdn0grlsbx6)
 
 Info about working group: [https://github.com/chaoss/wg-value](https://github.com/chaoss/wg-value)

--- a/Participate/web-content-call.md
+++ b/Participate/web-content-call.md
@@ -2,4 +2,4 @@
 
 This working group maintains the website and helps coordinate the distribution of CHAOSS messaging on internet platforms. Areas of interest include the website, Twitter, CHAOSScast, CHAOSStube, CHAOSSweekly, CHAOSSblog, CHAOSS metrics release, and press releases.
 
-The Web Content community call meets the First Monday of each month at 11:00am CST (usually 17:00 CET) via [Zoom](https://unomaha.zoom.us/j/720431288) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1p079Q75RZ2Duk-nX4osXY2v3oFjqF6-BTZG6XPx8iQ4/edit?usp=sharing)
+The Web Content community call meets the First Monday of each month at 11:00am CST (usually 17:00 CET) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1p079Q75RZ2Duk-nX4osXY2v3oFjqF6-BTZG6XPx8iQ4/edit?usp=sharing)


### PR DESCRIPTION
For Issue #451, this addresses all the individual pages but does *not* change the ics file. I'm not sure how to generate a link for international usage with our current account (on line 38 of CHAOSS-Calendar_WeeklySync.ics) so that part is TBD.

All changes on the individual meetings on the CHAOSS Google calendar have been made, however. 

cc @klumb 

Signed-off-by: Elizabeth Barron <elizabeth@naramore.net>