### PR TITLE
Add speakers and reorder based on schedule

### DIFF
--- a/CHAOSScon/2020-Shanghai-meetup/speakers.md
+++ b/CHAOSScon/2020-Shanghai-meetup/speakers.md
@@ -1,4 +1,25 @@
-## Speakers and Session Descriptions
+## Speakers 
+
+### Elizabeth Barron
+
+_Community Manager - CHAOSS_
+
+Elizabeth Barron has spent 20+ years in open source, and is currently the Community Manager for CHAOSS. She has written 2 fiction books, 3 technical books, given 37 talks, written 52 magazine articles and blog posts, appeared on 20 podcasts, and organized over 100 events, large and small. She loves to bring people together to connect with each other and loves building welcoming and inclusive communities. In her free time, she is a professional nature photographer, and enjoys spending time with her family. 
+
+### Ray Paik
+
+![Ray Paik](https://chaoss.github.io/website/CHAOSScon/2019EU/img/RayPaik.png)
+
+_Community Manager - GitLab_
+
+**Needs Updated Bio**
+
+### Ruth Ikegah
+
+_Title_
+
+**Needs Upated Bio**
+
 
 ### Daniel Izquierdo
 
@@ -8,36 +29,14 @@ _Data Analyst - Bitergia_
 
 Daniel Izquierdo is co-founder of Bitergia, a start-up focused on providing metrics and consultancy about open source projects. His main interests about open source are related to the community itself, trying to help community managers, organizations and developers to better understand how the project is performing. He has contributed to several open analytics dashboards such as the OpenStack, Wikimedia or Xen. He has participated as speaker giving details about gender diversity in OpenStack, InnerSource metrics strategy at OSCON, and other metrics-related talks.
 
-Session: **Putting order into CHAOSS: metrics to analyze code development**
+### Georg Link
 
-> CHAOSS Growth, Maturity and Decline working group provides several metrics definitions focused on code development. Using GrimoireLab we have put some of those definitions into action by setting up a collection of panels for tracking and visualizing specific datasets. During the talk we will present this collection of panels taking a deeper look to the metrics applied in a real use case.
+![Georg Link](https://chaoss.github.io/website/CHAOSScon/2019NA/img/GeorgLink.png)
 
-Session: **Creating a Collection of Panels**
+_Director of Sales - Bitergia_
 
-> During the last months, we have been dealing with dozens of panels and its number keeps increasing. It is expected to have many more, and it is becoming hard to deal with this amount of information. We need to scale!
->
-> The concept of collections of panels aims at bringing some order into the existing repository. A panel collection is just a set of Kibana dashboards. In this case, each panel is a Kibana dashboard consisting of a set of widgets.
->
-> GrimoireLab CHAOSS GMD code development metrics is an example where this concept can be applied. What about having a collection of GMD panels? This would be based on publicly available and could be built on top of GrimoreLab, so anyone can deploy the panels and get them working for their own purposes.
->
-> We will show the collection built on top real data, retrieved and processed by means of GrimoireLab projects. From that point, we will take a walk on the panels offering a closer look at the metrics. Looking at real numbers ease to get a deeper understanding of the metrics, as we can see them in action.
+Georg Link is an Open Source Community Strategist. Georg co-founded the Linux Foundation CHAOSS Project to advance analytics and metrics for open source project health. Georg has 13 years experience as an active contributor to several open source projects and has presented on open source topics at 18 conferences. Georg has an MBA and a Ph.D. in Information Technology. In his spare time, Georg enjoys reading fiction and hot-air ballooning. [@GeorgLink](https://twitter.com/georglink)
 
-Session: **Diversity & Inclusion WG Tutorial**
-
-> While it is recognized that diversity and inclusion are central to the health of open source communities, numbers lag and the ability to foster inclusive environments remains challenging. The CHAOSS Project’s Diversity & Inclusion Working group is focused on establishing a set of community-curated, peer-validated, research-informed standards and best practices to measure, and in turn, increase, diversity and inclusion across open source communities. In this interactive tutorial, you will contribute to this work by breaking into groups to define several diversity and inclusion metrics. Let’s work together to make our collective open source communities more welcoming, broader and heterogeneous.
-
-
-### Ray Paik
-
-![Ray Paik](https://chaoss.github.io/website/CHAOSScon/2019EU/img/RayPaik.png)
-
-_Community Manager - GitLab_
-
-Ray worked at the Linux Foundation and was responsible for the day-to-day operation of the OPNFV community since its launch in 2014. He has over 15 years of experience in the high-tech industry in roles ranging from software engineer, product manager, program manager, account manager, and team lead at companies such as EDS, Intel and Medallia. Ray lives in Sunnyvale, CA with his wife and daughter and all three are loyal season ticket holders of the San Jose Earthquakes soccer team.
-
-Session: **Metrics in a company-led open source project**
-
-> Ray used community metrics in two very different open source communities over the past 4+ years.  One was a foundation hosted project (www.opnfv.org) with dozens of member companies, and the other is a single-company led open source project at GitLab (https://about.gitlab.com/). In this session, Ray will discuss both similarities and different challenges that he has seen when working with metrics in these two communities. In addition, Ray will share learnings during his transition to a company-led project including identification of goals and stakeholders for community metrics.  Ray will then discuss how metrics are being used and analyzed at GitLab.
 
 ### Sean Goggins
 
@@ -47,20 +46,6 @@ _Professor - University of Missouri_
 
 Sean is an open source software researcher and a founding member of the Linux Foundation’s working group on community health analytics for open source software CHAOSS, co-lead of the CHAOSS metrics software working group and leader of the open source metrics tool AUGUR which can be forked and cloned and experimented with on GitHub. After a decade as a software engineer, Sean decided his calling was in research. His open source research is framed around a broader agenda of social computing research, which he pursues as an associate professor of computer science at the University of Missouri.
 
-Session: **Growth-Maturity-Decline WG Tutorial**
 
-> The GMD working group is exploring metrics related to growth-maturity-decline and other focus areas (such as risk). Our idea is to go top down, from the definition of the focus areas down to the goals that we want to fulfill in those areas, the questions that we would like to answer to reach those goals, and finally the metrics that could help us to better answer those questions. We also intend to work in reference implementations for the metrics. In parallel, we also work bottom-up, by collecting use case from real life.
->
-> This will be a workshop to explain all of this in more detail, to also explain our procedures, and how anyone can contribute. The workshop will also include a discussion on the current status of the working group, and on specific aspects of the focus areas, goals, questions and metrics we're considering. Anyone is welcome to submit issues and pull requests in advance, to propose topics of their interest.
 
-### Georg Link
 
-![Georg Link](https://chaoss.github.io/website/CHAOSScon/2019NA/img/GeorgLink.png)
-
-_Director of Sales - Bitergia_
-
-Georg Link is an Open Source Community Strategist. Georg co-founded the Linux Foundation CHAOSS Project to advance analytics and metrics for open source project health. Georg has 13 years experience as an active contributor to several open source projects and has presented on open source topics at 18 conferences. Georg has an MBA and a Ph.D. in Information Technology. In his spare time, Georg enjoys reading fiction and hot-air ballooning. [@GeorgLink](https://twitter.com/georglink)
-
-> Session: **Diversity & Inclusion WG Tutorial**
->
-> While it is recognized that diversity and inclusion are central to the health of open source communities, numbers lag and the ability to foster inclusive environments remains challenging. The CHAOSS Project’s Diversity & Inclusion Working group is focused on establishing a set of community-curated, peer-validated, research-informed standards and best practices to measure, and in turn, increase, diversity and inclusion across open source communities. In this interactive tutorial, you will contribute to this work by breaking into groups to define several diversity and inclusion metrics. Let’s work together to make our collective open source communities more welcoming, broader and heterogeneous.


### PR DESCRIPTION
This adds Ruth and Elizabeth and re-arranges the order of speakers to match the schedule. This also takes out the session summaries in the interest of expediting the website (the event is in 10 days, eep!).

Still missing: 
- Photo for Elizabeth
- Photo and bio for Ruth
- Updated bio for Ray

Signed-off-by: Elizabeth Barron <elizabeth@naramore.net>