### PR TITLE
update App Ecosystem WG times and minutes link

### DIFF
--- a/Participate/app-ecosystem-call.md
+++ b/Participate/app-ecosystem-call.md
@@ -2,4 +2,4 @@
 
 This working group applies CHAOSS metrics in the context of an open source app ecosystem. The mission of this working group is to build a base set of metrics that is focused on the needs of open source communities that are part of the FOSS app ecosystem.
 
-The App Ecosystem working group call meets every other Monday at 12:00pm CST (usually 19:00 CET), [check your local time](check your local time: https://arewemeetingyet.com/Chicago/2020-04-06/12:00/b/CHAOSS%20WG:%20App%20Ecosystem) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1HABrco2NGhchPLHK_PvKRsFHEU0fMfpnn0Axacv-OX8/edit)
+The App Ecosystem working group call meets every other Monday at 12:00 US Central Time, 18:00 UTC, 19:00 European Central Time, [check your local time](check your local time: https://arewemeetingyet.com/Chicago/2020-04-06/12:00/b/CHAOSS%20WG:%20App%20Ecosystem) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1lhZhIXQuYLlPg31htzfzUnJtOnoh7Xli18s7IxfLOHw/edit)


### PR DESCRIPTION
This PR updates the App Ecosystem WG meeting minutes link to the new document under the CHAOSSproject@gmail.com GDrive.

This PR also adds the UTC time information for meeting times.