### PR TITLE
Update meeting times and google Doc link

### DIFF
--- a/Participate/value-call.md
+++ b/Participate/value-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on industry-standard metrics for economic value in open source. The main goal is to publish trusted industry-standard Value Metrics. 
 
-The Value working group meets every other Thursday at 10:00am US Central Time / 4:00pm UTC / 5:00pm Central Europe Time via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1qWAV4ExtwcY3mSzIb9sYOUENt4Pi1BD7APjnRTCnZZs/edit#heading=h.bdn0grlsbx6)
+The Value working group meets every other Thursday at 9:00am US Central Time / 3:00pm UTC / 4:00pm Central Europe Time via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1Bf6a1Ywi4m0Ywo4vuBBp3Q9_AA_QKbWf99WxAqRbpMw/edit)
 
 Info about working group: [https://github.com/chaoss/wg-value](https://github.com/chaoss/wg-value)

--- a/Participate/value-call.md
+++ b/Participate/value-call.md
@@ -2,6 +2,7 @@
 
 This Working Group focuses on industry-standard metrics for economic value in open source. The main goal is to publish trusted industry-standard Value Metrics. 
 
-The Value working group meets every other Thursday at 9:00am US Central Time / 3:00pm UTC / 4:00pm Central Europe Time via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1Bf6a1Ywi4m0Ywo4vuBBp3Q9_AA_QKbWf99WxAqRbpMw/edit)
+The Value working group meets every other Thursday at 9:00am US Central Time / 3:00pm UTC / 4:00pm Central Europe Time, [check your local time](https://arewemeetingyet.com/Chicago/2021-02-11/09:50/b/CHAOSS%20Value%20WG%20Meeting) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1Bf6a1Ywi4m0Ywo4vuBBp3Q9_AA_QKbWf99WxAqRbpMw/edit)
 
 Info about working group: [https://github.com/chaoss/wg-value](https://github.com/chaoss/wg-value)
+https://arewemeetingyet.com/Chicago/2021-02-11/09:50/b/CHAOSS%20Value%20WG%20Meeting

--- a/Participate/value-call.md
+++ b/Participate/value-call.md
@@ -5,4 +5,3 @@ This Working Group focuses on industry-standard metrics for economic value in op
 The Value working group meets every other Thursday at 9:00am US Central Time / 3:00pm UTC / 4:00pm Central Europe Time, [check your local time](https://arewemeetingyet.com/Chicago/2021-02-11/09:50/b/CHAOSS%20Value%20WG%20Meeting) via [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1Bf6a1Ywi4m0Ywo4vuBBp3Q9_AA_QKbWf99WxAqRbpMw/edit)
 
 Info about working group: [https://github.com/chaoss/wg-value](https://github.com/chaoss/wg-value)
-https://arewemeetingyet.com/Chicago/2021-02-11/09:50/b/CHAOSS%20Value%20WG%20Meeting


### PR DESCRIPTION
Updating meeting times after the consent of regular participants and also updating google Docs link as the old Doc was owned by Andy. A new copy is created and ownership of the new one is transferred to CHAOSS project.

Signed-off-by: Vinod K. Ahuja  <vahuja@unomaha.edu>