### PR TITLE
Added hyperlinks to Augur, Grimoire Lab and Community Reports issue#536

### DIFF
--- a/release/community-report-metrics.md
+++ b/release/community-report-metrics.md
@@ -21,8 +21,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 * <a href="#">Project x</a>
 * <a href="#">Project y</a>
 
-***Visit <a href="#">here</a> to request a community report for your project***
+***Visit <a href="https://chaoss.community/community-reports/">here</a> to request a community report for your project***
 
 #### Communities reports are generated using CHAOSS software:
-* <a href="#">Augur</a>
-* <a href="#">Grimoire Lab</a>
+* <a href="https://chaoss.community/software/#user-content-augur">Augur</a>
+* <a href="https://chaoss.community/software/#user-content-grimoirelab">Grimoire Lab</a>


### PR DESCRIPTION
Signed-off-by: garimasingh2000 <garimasingh190200@gmail.com>

added the hyperlinks for the same on the metrics prototype page (links route to the pages of Augur and Grimoire Lab under "Software" menu)
Also did the same for the "community reports" mention.
Please let me know if instead of these links, they should route to the github repositories instead.