### PR TITLE
Fixed HTML form to Markdown text mapping

### DIFF
--- a/Programs/DIBadging/appmaster.html
+++ b/Programs/DIBadging/appmaster.html
@@ -218,7 +218,7 @@
 - [{sdcbIP}] This event commits to Speaker Diversity and Inclusion.
   - `Q` Detail the process for measuring Speaker Demographics.
   - `A` {sddscIP}
-  - `Q` Provide the link for the page related to Speaker Demographics if available.
+  - `Q` Provide an example of the Speaker Feedback page if available.
   - `A` {sdlinkIP}
 
 ## Attendee Demographics
@@ -226,7 +226,7 @@
 - [{adcbIP}] This event commits to Attendee Diversity and Inclusion.
   - `Q` Detail the process for measuring Attendee Demographics.
   - `A` {addscIP}
-  - `Q` Provide the link for the page related to Attendee Demographics if available.
+  - `Q` Provide an example of the Attendee Feedback page if available.
   - `A` {adlinkIP}
 
 ## Code of Conduct at Event
@@ -271,7 +271,7 @@
 - [{sdcbVI}] This event commits to Speaker Diversity and Inclusion.
   - `Q` Detail the process for measuring Speaker Demographics.
   - `A` {sddscVI}
-  - `Q` Provide the link for the page related to Speaker Demographics if available.
+  - `Q` Provide an example of the Speaker Feedback page if available.
   - `A` {sdlinkVI}
 
 ## Attendee Demographics
@@ -279,7 +279,7 @@
 - [{adcbVI}] This event commits to Attendee Diversity and Inclusion.
   - `Q` Detail the process for measuring Attendee Demographics.
   - `A` {addscVI}
-  - `Q` Provide the link for the page related to Attendee Demographics if available.
+  - `Q` Provide an example of the Attendee Feedback page if available.
   - `A` {adlinkVI}
 
 ## Code of Conduct at Event


### PR DESCRIPTION
This is a fix for https://github.com/badging/event-diversity-and-inclusion/issues/85#issuecomment-833555633

This fixes the Markdown question asking about Speaker Demographics to ask about Speaker Feedback page.

/cc @germonprez @ElizabethN