### PR TITLE
Update risk-call.md

### DIFF
--- a/Participate/risk-call.md
+++ b/Participate/risk-call.md
@@ -2,6 +2,6 @@
 
 This Working Group focuses on Compliance and Risk metrics. The goal is to refine the metrics that inform Risk and to work with software implementations.
 
-The Risk working group meets every other Thursday at 7:00pm UTC / 2:00pm US Central Time / 9:00pm Central European Time via / 3:00 am Beijing Time [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1iqIMpLBwuKSnE0BbQTgbsb9Im87IoN7IUzukochClCw/edit)
+The Risk working group meets every other Thursday at 7:00pm UTC / 2:00pm US Central Time / 8:00pm Central European Time via / 3:00 am Beijing Time [Zoom](https://zoom.us/j/4998687533) -- [Agenda and Meeting Minutes](https://docs.google.com/document/d/1iqIMpLBwuKSnE0BbQTgbsb9Im87IoN7IUzukochClCw/edit)
 
 Info about working group: [https://github.com/chaoss/wg-risk](https://github.com/chaoss/wg-risk)


### PR DESCRIPTION
Signed-off-by: Matt Germonprez <germonprez@gmail.com>

Updating the CET fall back on Oct 31