### PR TITLE
Add Diversity Access Tickets and Family Friendliness

### DIFF
--- a/CHAOSScon/2022EU/event-details.md
+++ b/CHAOSScon/2022EU/event-details.md
@@ -10,3 +10,14 @@ All speakers and attendees are required to adhere to the Linux Foundation's [Eve
 Subscribe to our [Slack Channel](https://join.slack.com/t/chaoss-workspace/shared_invite/zt-r65szij9-QajX59hkZUct82b0uACA6g) #CHAOSScon for updates about the conference and to coordinate meetups.  
 
 Follow [@CHAOSSproj](https://twitter.com/CHAOSSproj) and tweet #CHAOSS #CHAOSScon during the Summit and CHAOSScon to let everyone know how important open source community health is!
+
+### Diversity Access Tickets and Family Friendliness
+
+This event is co-located with the Open Source Summit EU, and the Linux Foundation offers [Diversity Access and Need-Based Scholarship Tickets](https://events.linuxfoundation.org/open-source-summit-europe/attend/scholarships/#scholarships). CHAOSS and The LF also provide support in terms of [travel funding for those who are in need](https://events.linuxfoundation.org/open-source-summit-europe/attend/travel-funding/). Additionally, CHAOSScon will be livestreamed for free to virtual participants.
+
+With regard to family friendliness, The Linux Foundatiion provides: 
+- [on-site childcare at the venue](https://events.linuxfoundation.org/open-source-summit-europe/attend/child-care/)
+- [on-site nursing room at the venue](https://events.linuxfoundation.org/open-source-summit-europe/attend/child-care/)
+- [family friendly social events, including a boat tour, 5K Fun Run, and a tea bus tour](https://events.linuxfoundation.org/open-source-summit-europe/features/onsite-activities/)
+ 
+The CHAOSScon team also plans to host an informal family friendly outing after CHAOSScon, but the details are to be determined. We recommend you join the [#CHAOSScon slack channel](https://chaoss-workspace.slack.com/archives/C02EMK6RAKT) for up-to-date information.


### PR DESCRIPTION
Based on a recommendation from [CHAOSScon's DEI Badging application,](https://github.com/badging/event-diversity-and-inclusion/issues/188) we'd like to increase visibility of our attentiveness to Diversity Access Tickets and Family Friendliness by adding a section for these things on the CHAOSScon site.

Signed-off-by: Elizabeth Barron <elizabeth@naramore.net>