### PR TITLE
Publishing the preliminary schedule for CHAOSScon 2023 in Vancouver

### DIFF
--- a/CHAOSScon/2023NA/schedule.md
+++ b/CHAOSScon/2023NA/schedule.md
@@ -4,7 +4,8 @@
 
 | Time | Topic | Speaker |
 | --- | -- | --- |
-| 1:00pm | Check-in, networking, and coffee/tea |
+| 1:00-1:30 | Check-in, networking, and coffee/tea |
+
 | 1:30-1:50 | Welcome and State of CHAOSS | Georg Link, Bitergia |
 | 1:55-2:15 | Keynote 1: How do we build  towards sustainability? | Sophia Vargas, Google |
 | 2:20-2:40 | Discussion session in small groups|

--- a/CHAOSScon/2023NA/schedule.md
+++ b/CHAOSScon/2023NA/schedule.md
@@ -2,4 +2,14 @@
 
 ### May 9, 2023 from 1:00 pm - 5:30 pm Pacific Daylight Time 
 
-Schedule is coming soon! 
+| Time | Topic | Speaker |
+| --- | -- | --- |
+| 1:00pm | Check-in, networking, and coffee/tea |
+| 1:30-1:50 | Welcome and State of CHAOSS | Georg Link, Bitergia |
+| 1:55-2:15 | Keynote 1: How do we build  towards sustainability? | Sophia Vargas, Google |
+| 2:20-2:40 | Discussion session in small groups|
+| 2:40-2:55 | Break with coffee/tea |
+| 3:00-3:20 | Keynote 2: How do you interpret, motivate to improve, and share results of OSS community health-related findings within an organization? | Emma Irwin, Microsoft |
+| 3:20-3:40 | Discussion session in small groups|
+| 3:45-4:30 | Keynote 3: CHAOSS software updates with real time demonstrations | Sean Goggins, University of Missouri and Georg Link, Bitergia |
+| 4:30-5:00 | Lightning Talk Style Large group discussion, sharing what was discussed wrapup|


### PR DESCRIPTION
Signed-off-by: Matt Germonprez <germonprez@gmail.com>

Publishing the preliminary schedule for CHAOSScon 2023 in Vancouver. I suspect there might be changes but this gets the schedule primarily set.

