### PR TITLE
CHAOSScon EU 2027 README

### DIFF
--- a/CHAOSScon/2027Europe/README.md
+++ b/CHAOSScon/2027Europe/README.md
@@ -1,0 +1,12 @@
+# README.md
+
+Here are a few things we need to keep track of until we get the CHAOSScon EU 2027 website up and running.
+
+# Sponsors
+
+| Sponsor | Level | Amount | Paid |
+-----------------------------------
+| Google | Silver | $1500 | No |
+| OpenSUSE | Bronze | $1000 | No |
+| AWS | TBD | TBD | No |
+

--- a/CHAOSScon/2027Europe/README.md
+++ b/CHAOSScon/2027Europe/README.md
@@ -5,7 +5,7 @@ Here are a few things we need to keep track of until we get the CHAOSScon EU 202
 # Sponsors
 
 | Sponsor | Level | Amount | Paid |
------------------------------------
+|---------|-------|--------|------|
 | Google | Silver | $1500 | No |
 | OpenSUSE | Bronze | $1000 | No |
 | AWS | TBD | TBD | No |


### PR DESCRIPTION
adding a README to track sponsorship (and any other details) until the CHAOSScon EU web page is online.